### PR TITLE
Expose central mapping under /sites entdpoint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,3 +41,4 @@ hyper_serde = "0.13"
 clap = {version = "3", features = ["derive"]}
 
 thiserror = "*"
+http-serde = "1.1.2"

--- a/src/logic_ask.rs
+++ b/src/logic_ask.rs
@@ -33,6 +33,21 @@ pub(crate) async fn handler_http(
     //     return Err(StatusCode::CONFLICT.into());
     // }
 
+    // If the autority is empty (e.g. if localhost is used) or the authoroty is not in the routing
+    // table AND the path is /sites, return global routing table
+    if let Some(path) = uri.path_and_query() { 
+        if (uri.authority().is_none() || targets.get(uri.authority().unwrap()).is_none()) && path == "/sites" {
+            debug!("Central Site Discovery requested");
+            let body = body::Body::from(serde_json::to_string(targets)?);
+            let response = Response::builder()
+                .status(200)
+                .body(body)
+                .unwrap();
+            return Ok(response);
+
+        }
+    }
+
     let target = targets.get(uri.authority().unwrap()) //TODO unwrap
         .ok_or(StatusCode::UNAUTHORIZED)?
         .beamconnect;


### PR DESCRIPTION
Expose the global mapping received from the `DISCOVERY_URL` environment variable as a `/sites` REST endpoint.

- [X] Implementation
- [ ] Documentation @TKussel 