### PR TITLE
Update beam-connect to match new beam library and add tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 /target
 **/Cargo.lock
+dev/pki/*
+!dev/pki/pki
+artifacts/

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,15 +1,18 @@
 # This assumes binaries are present, see COPY directive.
 
+ARG IMGNAME=gcr.io/distroless/cc
+
 FROM alpine AS chmodder
 ARG TARGETARCH
 COPY /artifacts/binaries-$TARGETARCH/connect /app/
 RUN chmod +x /app/*
 
-FROM gcr.io/distroless/cc
+FROM ${IMGNAME}
 #ARG COMPONENT
 ARG TARGETARCH
 #COPY /artifacts/binaries-$TARGETARCH/$COMPONENT /usr/local/bin/
 COPY --from=chmodder /app/* /usr/local/bin/
 #ENTRYPOINT [ "/usr/local/bin/$COMPONENT" ]
 ENTRYPOINT [ "/usr/local/bin/connect" ]
+# ENTRYPOINT ["tail", "-f", "/dev/null"]
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ A mishap in communication will be returned as appropriate HTTP replies.
 
 #### Site Discovery
 
-As described in the [command line parameter list](#run-as-an-application), the central cite discovery is fetched from a given URL. However, to spare the local services from the need to express outward facing connections themselves, Samply.Beam.Connect exports this received information as a local REST endpoint: `GET http://<beam_connect_url>:<beam_connect_port>/sites`. Note, that the information is only fetched at startup and remains static for the program's lifetime.
+As described in the [command line parameter list](#run-as-an-application), the central cite discovery is fetched from a given URL or local json file. However, to spare the local services from the need to express outward facing connections themselves, Samply.Beam.Connect exports this received information as a local REST endpoint: `GET http://<beam_connect_url>:<beam_connect_port>/sites`. Note, that the information is only fetched at startup and remains static for the program's lifetime.
 
 ## Notes
 At the moment Samply.Beam.Connect does not implement streaming and does not support HTTPS connections. In the intended usage scenario, both Samply.Beam.Connect and Samply.Beam.Proxy are positioned right next to each other in the same privileged network and thus speak plain HTTP. Of course, for outgoing traffic, the Samply.Proxy signs and encrypts the payloads on its own.

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -62,8 +62,27 @@ services:
       PROXY_URL: "http://proxy1:8081"
       APP_ID: ${APP1_P1}
       PROXY_APIKEY: ${APP_KEY}
-      DISCOVERY_URL: "./map/example_central_mapping.json"
+      DISCOVERY_URL: "./map/example_central_test.json"
       RUST_LOG: ${RUST_LOG}
+  connect2:
+   depends_on:
+     - proxy2
+   build:
+     context: ../
+     dockerfile: Dockerfile.ci
+   image: samply/beam-connect:${TAG}
+   ports:
+     - 8063:8063
+   volumes:
+     - ../examples/:/map
+   environment:
+     PROXY_URL: "http://proxy2:8082"
+     BIND_ADDR: 0.0.0.0:8063
+     APP_ID: ${APP2_P2}
+     PROXY_APIKEY: ${APP_KEY}
+     DISCOVERY_URL: "./map/example_central_test.json"
+     LOCAL_TARGETS_FILE: "./map/example_local_test.json"
+     RUST_LOG: ${RUST_LOG}
   proxy2:
     depends_on: [broker]
     image: samply/beam-proxy:${TAG}

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -1,0 +1,95 @@
+version: "3.7"
+services:
+  vault:
+    image: vault
+    ports:
+      - 127.0.0.1:8200:8200
+    environment:
+      VAULT_DEV_ROOT_TOKEN_ID: ${VAULT_TOKEN}
+      VAULT_DEV_LISTEN_ADDRESS: 0.0.0.0:8200
+      VAULT_ADDR: http://0.0.0.0:8200
+    volumes:
+      - ./pki:/pki
+    networks:
+      - default
+  broker:
+    depends_on: [vault]
+    image: samply/beam-broker:${TAG}
+    ports:
+      - 8080:8080
+    environment:
+      BROKER_URL: ${BROKER_URL}
+      PKI_ADDRESS: http://vault:8200
+      no_proxy: vault
+      NO_PROXY: vault
+      PRIVKEY_FILE: /run/secrets/dummy.pem
+      BIND_ADDR: 0.0.0.0:8080
+      RUST_LOG: ${RUST_LOG}
+    secrets:
+      - pki.secret
+      - dummy.pem
+      - root.crt.pem
+  proxy1:
+    depends_on: [broker]
+    image: samply/beam-proxy:${TAG}
+    ports:
+      - 8081:8081
+    environment:
+      BROKER_URL: ${BROKER_URL}
+      PROXY_ID: ${PROXY1_ID}
+      APP_0_ID: ${APP1_ID_SHORT}
+      APP_0_KEY: ${APP_KEY}
+      APP_1_ID: ${APP2_ID_SHORT}
+      APP_1_KEY: ${APP_KEY}
+      PRIVKEY_FILE: /run/secrets/proxy1.pem
+      BIND_ADDR: 0.0.0.0:8081
+      RUST_LOG: ${RUST_LOG}
+    secrets:
+      - proxy1.pem
+      - root.crt.pem
+  connect1:
+    depends_on:
+      - proxy1
+    build:
+      context: ../
+      dockerfile: Dockerfile.ci
+    image: samply/beam-connect:${TAG}
+    ports:
+      - 8062:8062
+    volumes:
+      - ../examples/:/map
+    environment:
+      PROXY_URL: "http://proxy1:8081"
+      APP_ID: ${APP1_P1}
+      PROXY_APIKEY: ${APP_KEY}
+      DISCOVERY_URL: "./map/example_central_mapping.json"
+      RUST_LOG: ${RUST_LOG}
+  proxy2:
+    depends_on: [broker]
+    image: samply/beam-proxy:${TAG}
+    ports:
+      - 8082:8082
+    environment:
+      BROKER_URL: ${BROKER_URL}
+      PROXY_ID: ${PROXY2_ID}
+      APP_0_ID: ${APP1_ID_SHORT}
+      APP_0_KEY: ${APP_KEY}
+      APP_1_ID: ${APP2_ID_SHORT}
+      APP_1_KEY: ${APP_KEY}
+      PRIVKEY_FILE: /run/secrets/proxy2.pem
+      BIND_ADDR: 0.0.0.0:8082
+      RUST_LOG: ${RUST_LOG}
+    secrets:
+      - proxy2.pem
+      - root.crt.pem
+secrets:
+  pki.secret:
+    file: ./pki/pki.secret
+  proxy1.pem:
+    file: ./pki/${PROXY1_ID_SHORT}.priv.pem
+  proxy2.pem:
+    file: ./pki/${PROXY2_ID_SHORT}.priv.pem
+  dummy.pem:
+    file: ./pki/dummy.priv.pem
+  root.crt.pem:
+    file: ./pki/root.crt.pem

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -44,6 +44,8 @@ services:
       PRIVKEY_FILE: /run/secrets/proxy1.pem
       BIND_ADDR: 0.0.0.0:8081
       RUST_LOG: ${RUST_LOG}
+      NO_PROXY: broker
+      no_proxy: broker
     secrets:
       - proxy1.pem
       - root.crt.pem
@@ -64,6 +66,8 @@ services:
       PROXY_APIKEY: ${APP_KEY}
       DISCOVERY_URL: "./map/example_central_test.json"
       RUST_LOG: ${RUST_LOG}
+      NO_PROXY: proxy1
+      no_proxy: proxy1
   connect2:
    depends_on:
      - proxy2
@@ -83,6 +87,8 @@ services:
      DISCOVERY_URL: "./map/example_central_test.json"
      LOCAL_TARGETS_FILE: "./map/example_local_test.json"
      RUST_LOG: ${RUST_LOG}
+     NO_PROXY: proxy2
+     no_proxy: proxy2
   proxy2:
     depends_on: [broker]
     image: samply/beam-proxy:${TAG}
@@ -98,6 +104,8 @@ services:
       PRIVKEY_FILE: /run/secrets/proxy2.pem
       BIND_ADDR: 0.0.0.0:8082
       RUST_LOG: ${RUST_LOG}
+      NO_PROXY: broker
+      no_proxy: broker
     secrets:
       - proxy2.pem
       - root.crt.pem

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -39,8 +39,6 @@ services:
       PROXY_ID: ${PROXY1_ID}
       APP_0_ID: ${APP1_ID_SHORT}
       APP_0_KEY: ${APP_KEY}
-      APP_1_ID: ${APP2_ID_SHORT}
-      APP_1_KEY: ${APP_KEY}
       PRIVKEY_FILE: /run/secrets/proxy1.pem
       BIND_ADDR: 0.0.0.0:8081
       RUST_LOG: ${RUST_LOG}
@@ -97,10 +95,8 @@ services:
     environment:
       BROKER_URL: ${BROKER_URL}
       PROXY_ID: ${PROXY2_ID}
-      APP_0_ID: ${APP1_ID_SHORT}
+      APP_0_ID: ${APP2_ID_SHORT}
       APP_0_KEY: ${APP_KEY}
-      APP_1_ID: ${APP2_ID_SHORT}
-      APP_1_KEY: ${APP_KEY}
       PRIVKEY_FILE: /run/secrets/proxy2.pem
       BIND_ADDR: 0.0.0.0:8082
       RUST_LOG: ${RUST_LOG}

--- a/dev/pki/pki
+++ b/dev/pki/pki
@@ -1,0 +1,124 @@
+#!/bin/bash -e
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+#ME="$(basename "$(test -L "$0" && readlink "$0" || echo "$0")")"
+
+[ -z "$PROXY1_ID" ] && ( echo "PROXY1_ID not set!"; exit 1)
+[ -z "$PROXY2_ID" ] && ( echo "PROXY2_ID not set!"; exit 1)
+
+cd $SCRIPT_DIR
+export PROXY1_ID_SHORT=$(echo $PROXY1_ID | cut -d '.' -f 1)
+export PROXY2_ID_SHORT=$(echo $PROXY2_ID | cut -d '.' -f 1)
+export BROKER_ID=$(echo $PROXY1_ID | cut -d '.' -f 2-)
+export VAULT_ADDR=http://127.0.0.1:8200
+
+function start() {
+     docker-compose up -d --no-build vault
+}
+
+function clean() {
+     rm -vf *.pem *.json *.secret
+     docker-compose down
+}
+
+function create_root_ca() {
+     vault secrets enable pki
+     vault secrets tune -max-lease-ttl=87600h pki
+     vault write -field=certificate pki/root/generate/internal \
+          common_name="Broker-Root" \
+          issuer_name="root-2022" \
+          ttl=87600h > dktk_root_2022_ca.crt.pem
+     vault write pki/roles/2022-servers_root allow_any_name=true
+     cp dktk_root_2022_ca.crt.pem root.crt.pem
+}
+
+function create_intermediate_ca() {
+     vault secrets enable -path=samply_pki pki
+     vault secrets tune -max-lease-ttl=43800h samply_pki
+     vault write -format=json samply_pki/intermediate/generate/internal \
+          common_name="$BROKER_ID Intermediate Authority" \
+          issuer_name="$BROKER_ID-intermediate" \
+          | jq -r '.data.csr' > pki_hd_intermediate.csr.pem
+     vault write -format=json pki/root/sign-intermediate \
+          issuer_ref="root-2022" \
+          csr=@pki_hd_intermediate.csr.pem \
+          format=pem_bundle ttl="43800h" \
+          | jq -r '.data.certificate' > hd_intermediate.crt.pem
+     vault write samply_pki/intermediate/set-signed certificate=@hd_intermediate.crt.pem
+     vault write samply_pki/roles/hd-dot-dktk-dot-com \
+          issuer_ref="$(vault read -field=default samply_pki/config/issuers)" \
+          allowed_domains="$BROKER_ID" \
+          allow_subdomains=true \
+          allow_glob_domains=true \
+          max_ttl="720h"
+}
+
+function request_proxy() {
+     application="${1:-app1}"
+     ttl="${2:-24h}"
+     cn="${application}.$BROKER_ID"
+     request "$application" "$cn" "$ttl" 
+}
+
+function request() {
+     application=$1
+     cn=$2
+     ttl=$3
+     data="{\"common_name\": \"$cn\", \"ttl\": \"$ttl\"}"
+     echo $data
+     echo "Creating Certificate for domain $cn"
+     curl --header "X-Vault-Token: $VAULT_TOKEN" \
+          --request POST \
+          --data "$data" \
+          --no-progress-meter \
+     $VAULT_ADDR/v1/samply_pki/issue/hd-dot-dktk-dot-com | jq > ${application}.json
+     cat ${application}.json | jq -r .data.certificate > ${application}.crt.pem
+     cat ${application}.json | jq -r .data.ca_chain[] > ${application}.chain.pem
+     cat ${application}.json | jq -r .data.private_key > ${application}.priv.pem
+     echo "Success: PEM files stored to ${application}*.pem"
+}
+
+function init() {
+     echo "Creating Root CA"
+     create_root_ca
+
+     echo "Creating Intermediate HD CA"
+     create_intermediate_ca
+
+     echo "Successfully completed 'init'."
+}
+
+case "$1" in
+     start)
+          start
+          ;;
+     clean)
+          clean
+          ;;
+     init)
+          init
+          ;;
+     request_proxy)
+          request_proxy $2 $3
+          ;;
+     devsetup)
+          clean
+          touch ${PROXY1_ID_SHORT}.priv.pem # see https://github.com/docker/compose/issues/8305
+          touch ${PROXY2_ID_SHORT}.priv.pem # see https://github.com/docker/compose/issues/8305
+          touch test1.priv.pem # see https://github.com/docker/compose/issues/8305
+          touch test2.priv.pem # see https://github.com/docker/compose/issues/8305
+          #touch root.crt.pem # see https://github.com/docker/compose/issues/8305
+          start
+          while ! [ "$(curl -s $VAULT_ADDR/v1/sys/health | jq -r .sealed)" == "false" ]; do echo "Waiting ..."; sleep 0.1; done
+          docker-compose exec -T vault sh -c "https_proxy=$http_proxy apk add --no-cache bash curl jq"
+          docker-compose exec -T vault sh -c "VAULT_TOKEN=$VAULT_TOKEN http_proxy= HTTP_PROXY= PROXY1_ID=$PROXY1_ID PROXY2_ID=$PROXY2_ID /pki/pki init"
+          docker-compose exec -T vault sh -c "VAULT_TOKEN=$VAULT_TOKEN http_proxy= HTTP_PROXY= PROXY1_ID=$PROXY1_ID PROXY2_ID=$PROXY2_ID /pki/pki request_proxy $PROXY1_ID_SHORT" "24h"
+          docker-compose exec -T vault sh -c "VAULT_TOKEN=$VAULT_TOKEN http_proxy= HTTP_PROXY= PROXY1_ID=$PROXY1_ID PROXY2_ID=$PROXY2_ID /pki/pki request_proxy $PROXY2_ID_SHORT" "24h"
+          docker-compose exec -T vault sh -c "VAULT_TOKEN=$VAULT_TOKEN http_proxy= HTTP_PROXY= PROXY1_ID=$PROXY1_ID PROXY2_ID=$PROXY2_ID /pki/pki request_proxy dummy" "24h"
+          docker-compose exec -T vault sh -c "VAULT_TOKEN=$VAULT_TOKEN http_proxy= HTTP_PROXY= PROXY1_ID=$PROXY1_ID PROXY2_ID=$PROXY2_ID /pki/pki request_proxy test1 2s"
+          docker-compose exec -T vault sh -c "VAULT_TOKEN=$VAULT_TOKEN http_proxy= HTTP_PROXY= PROXY1_ID=$PROXY1_ID PROXY2_ID=$PROXY2_ID /pki/pki request_proxy test2 2s"
+          ;;
+     *)
+          echo "Usage: $0 start|init|(request [AppName])"
+          ;;
+esac

--- a/dev/pki/pki
+++ b/dev/pki/pki
@@ -115,8 +115,6 @@ case "$1" in
           docker-compose exec -T vault sh -c "VAULT_TOKEN=$VAULT_TOKEN http_proxy= HTTP_PROXY= PROXY1_ID=$PROXY1_ID PROXY2_ID=$PROXY2_ID /pki/pki request_proxy $PROXY1_ID_SHORT" "24h"
           docker-compose exec -T vault sh -c "VAULT_TOKEN=$VAULT_TOKEN http_proxy= HTTP_PROXY= PROXY1_ID=$PROXY1_ID PROXY2_ID=$PROXY2_ID /pki/pki request_proxy $PROXY2_ID_SHORT" "24h"
           docker-compose exec -T vault sh -c "VAULT_TOKEN=$VAULT_TOKEN http_proxy= HTTP_PROXY= PROXY1_ID=$PROXY1_ID PROXY2_ID=$PROXY2_ID /pki/pki request_proxy dummy" "24h"
-          docker-compose exec -T vault sh -c "VAULT_TOKEN=$VAULT_TOKEN http_proxy= HTTP_PROXY= PROXY1_ID=$PROXY1_ID PROXY2_ID=$PROXY2_ID /pki/pki request_proxy test1 2s"
-          docker-compose exec -T vault sh -c "VAULT_TOKEN=$VAULT_TOKEN http_proxy= HTTP_PROXY= PROXY1_ID=$PROXY1_ID PROXY2_ID=$PROXY2_ID /pki/pki request_proxy test2 2s"
           ;;
      *)
           echo "Usage: $0 start|init|(request [AppName])"

--- a/dev/start
+++ b/dev/start
@@ -1,0 +1,111 @@
+#!/bin/bash -e
+
+# https://stackoverflow.com/questions/59895/
+SOURCE=${BASH_SOURCE[0]}
+while [ -L "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR=$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )
+  SOURCE=$(readlink "$SOURCE")
+  [[ $SOURCE != /* ]] && SOURCE=$DIR/$SOURCE # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+SD=$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )
+
+cd $SD
+
+export PROXY1_ID=${PROXY1_ID:-proxy1.broker}
+export PROXY2_ID=${PROXY2_ID:-proxy2.broker}
+export PROXY1_ID_SHORT=$(echo $PROXY1_ID | cut -d '.' -f 1)
+export PROXY2_ID_SHORT=$(echo $PROXY2_ID | cut -d '.' -f 1)
+export BROKER_ID=$(echo $PROXY1_ID | cut -d '.' -f 2-)
+export BROKER_URL=http://broker:8080
+export APP1_ID_SHORT=app1
+export APP2_ID_SHORT=app2
+export APP1_P1=${APP1_ID_SHORT}.$PROXY1_ID
+export APP2_P1=${APP2_ID_SHORT}.$PROXY1_ID
+export APP1_P2=${APP1_ID_SHORT}.$PROXY2_ID
+export APP2_P2=${APP2_ID_SHORT}.$PROXY2_ID
+export APP_KEY=App1Secret
+export RUST_LOG=${RUST_LOG:-info}
+
+export P1="http://localhost:8081" # for scripts
+export P2="http://localhost:8082" # for scripts
+
+export VAULT_TOKEN=$(echo $RANDOM | md5sum | head -c 20; echo;)
+
+export ARCH=$(docker version --format "{{.Server.Arch}}")
+export TAG=${TAG:-develop}
+
+function image_for_docker() {
+     # Pick the correct Ubuntu version for the Docker image,
+     # so the locally-built rust binary works regarding libssl
+     if [[ "$(pkg-config --modversion libssl)" =~ ^3.* ]]; then
+          echo "ubuntu:latest" # Use libssl3
+     else
+          echo -n "" # Don't change (uses libssl1.1)
+     fi
+}
+
+export IMGNAME="$(image_for_docker)"
+
+function build() {
+    BUILD_DOCKER=0
+    BACK=$(pwd)
+    cd $SD/..
+    CONNECT=./target/debug/connect
+    if [ ! -x ./artifacts/binaries-$ARCH ]; then
+        echo "Binaries missing -- building ..."
+        BUILD="$(cargo build --message-format=json)"
+        echo "Will rebuild docker image since binaries had not been there."
+        mkdir -p artifacts/binaries-$ARCH
+        rsync "$CONNECT" artifacts/binaries-$ARCH/
+        BUILD_DOCKER=1
+    elif [ -z "$(docker images -q samply/beam-broker:$TAG)" ] || [ -z "$(docker images -q samply/beam-proxy:$TAG)" ]; then
+        echo "Will rebuild docker image since it is missing."
+        BUILD_DOCKER=1
+    elif [ -x ./target ]; then
+        echo "Checking for changed Rust source code ..."
+        BUILD="$(cargo build --message-format=json)"
+        if echo $BUILD | jq 'select(.fresh==false)' | grep -q 'fresh'; then
+            echo "Will rebuild docker image due to changes in rust binaries."
+            rsync "$CONNECT" artifacts/binaries-$ARCH/
+            BUILD_DOCKER=1
+        fi
+    fi
+    if [ $BUILD_DOCKER -eq 1 ]; then
+        build_docker
+    else
+        echo "Not rebuilding docker image since nothing has changed."
+    fi
+    cd $BACK
+}
+
+function build_docker() {
+    BACK2=$(pwd)
+    cd $SD
+    if [ -z "$IMGNAME" ]; then
+        docker-compose build --build-arg TARGETARCH=$ARCH
+    else
+        docker-compose build --build-arg TARGETARCH=$ARCH --build-arg IMGNAME=$IMGNAME
+    fi
+    cd $BACK2
+}
+
+function clean() {
+    stop
+    rm -rfv artifacts/
+}
+
+function stop {
+    docker-compose down
+    rm -fv pki/*.pem pki/*.json pki/pki.secret
+    pki/pki clean
+}
+
+function start {
+    clean
+    pki/pki devsetup
+    echo "$VAULT_TOKEN" > ./pki/pki.secret
+    build
+    docker-compose up --no-build --no-recreate --abort-on-container-exit
+}
+
+start

--- a/dev/test.py
+++ b/dev/test.py
@@ -22,7 +22,7 @@ class TestConnect(unittest.TestCase):
         }
         res = request_connect("http://httpbin.org/anything", json=json)
         self.assertEqual(res.status_code, 200, "Could not make normal request via connect")   
-        self.assertEqual(res.json(), json, "Json did not match")
+        self.assertEqual(res.json().get("json"), json, "Json did not match")
 
 
 def request_connect(url: str, json = {}, app_id: str = "app1.proxy1.broker", app_secret: str = "App1Secret", proxy_url: str = "http://localhost:8062") -> requests.Response:

--- a/dev/test.py
+++ b/dev/test.py
@@ -1,0 +1,43 @@
+
+try:
+    import requests
+except ImportError:
+    import os
+    os.system("python3 -m pip install requests")
+    import requests
+
+import unittest
+
+class TestConnect(unittest.TestCase):
+
+    def test_normal_request(self):
+        res = request_connect("http://httpbin.org/anything")
+        self.assertEqual(res.status_code, 200, "Could not make normal request via connect")
+    
+    def test_json_body(self):
+        json = {
+            "foo": "bar",
+            "asdf": 3,
+            "baz": [{}, 2]
+        }
+        res = request_connect("http://httpbin.org/anything", json=json)
+        self.assertEqual(res.status_code, 200, "Could not make normal request via connect")   
+        self.assertEqual(res.json(), json, "Json did not match")
+
+
+def request_connect(url: str, json = {}, app_id: str = "app1.proxy1.broker", app_secret: str = "App1Secret", proxy_url: str = "http://localhost:8062") -> requests.Response:
+    proxies = {
+        "http": proxy_url
+    }
+    headers = {
+        "Proxy-Authorization": f"ApiKey {app_id} {app_secret}",
+        "Accept": "application/json"
+    }
+    return requests.get(url, json=json, proxies=proxies, headers=headers)
+
+
+def main():
+    unittest.main()
+
+if __name__ == "__main__":
+    main()

--- a/examples/example_central_test.json
+++ b/examples/example_central_test.json
@@ -1,0 +1,10 @@
+{
+    "sites": [
+        {
+            "id": "C2",
+            "name": "connect2",
+            "virtualhost": "httpbin.org",
+            "beamconnect": "app2.proxy2.broker"
+        }
+    ]
+}

--- a/examples/example_local_test.json
+++ b/examples/example_local_test.json
@@ -1,0 +1,7 @@
+[
+    {
+        "external": "httpbin.org",
+        "internal": "httpbin.org",
+        "allowed": ["app1.proxy1.broker"]
+    }
+]

--- a/src/config.rs
+++ b/src/config.rs
@@ -84,6 +84,7 @@ impl CentralMapping {
     }
 }
 
+/// Maps an Authority to a given Beam App
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub(crate) struct Site {
     pub(crate) id: String,
@@ -108,6 +109,7 @@ impl LocalMapping {
     }
 }
 
+/// Maps an external authority to some internal authority if the requesting App is allowed to
 #[derive(Clone,Deserialize,Debug)]
 pub(crate) struct LocalMappingEntry {
     #[serde(with = "http_serde::authority", rename="external")]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,10 +1,8 @@
-use std::{error::Error, str::FromStr, path::PathBuf};
+use std::{error::Error, path::PathBuf};
 
 use clap::Parser;
-use hyper::{Uri, http::uri::Authority, client::HttpConnector, Client};
-use hyper_proxy::ProxyConnector;
-use hyper_tls::HttpsConnector;
-use serde::{Serialize, Deserialize, Deserializer, de::Visitor};
+use hyper::{Uri, http::uri::Authority};
+use serde::{Serialize, Deserialize};
 use shared::{beam_id::{AppId, BeamId, app_to_broker_id, BrokerId}, http_client::{SamplyHttpClient, self}};
 
 use crate::{example_targets, errors::BeamConnectError};
@@ -51,17 +49,17 @@ pub(crate) struct CentralMapping {
 }
 
 impl CentralMapping {
-    pub(crate) fn get(&self, auth: &Authority) -> Option<Site> {
+    pub(crate) fn get(&self, auth: &Authority) -> Option<&Site> {
         for site in &self.sites {
             if site.virtualhost == *auth {
-                return Some(site.clone())
+                return Some(site)
             }
         }
         return None
     }
 }
 
-#[derive(Serialize, Deserialize,Clone,Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub(crate) struct Site {
     pub(crate) id: String,
     pub(crate) name: String,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -13,7 +13,7 @@ pub(crate) enum BeamConnectError {
     #[error("Unable to communicate with Proxy: {0}")]
     ProxyOtherError(String),
     #[error("Constructing HTTP request failed: {0}")]
-    HyperBuildError(hyper::http::Error),
+    HyperBuildError(#[from] hyper::http::Error),
     #[error("Error in (de-)serialization from/to JSON: {0}")]
     SerdeError(#[from] serde_json::Error),
     #[error("AppId {0} is not authorized to access URL {1}")]

--- a/src/logic_ask.rs
+++ b/src/logic_ask.rs
@@ -5,6 +5,7 @@ use hyper_proxy::ProxyConnector;
 use hyper_tls::HttpsConnector;
 use log::{info, debug, warn, error};
 use serde_json::Value;
+use shared::http_client::SamplyHttpClient;
 use shared::{beam_id::AppId, MsgTaskResult, MsgTaskRequest};
 
 use crate::{config::Config, structs::MyStatusCode, msg::{HttpRequest, HttpResponse}, errors::BeamConnectError};
@@ -15,8 +16,8 @@ use crate::{config::Config, structs::MyStatusCode, msg::{HttpRequest, HttpRespon
 pub(crate) async fn handler_http(
     mut req: Request<Body>,
     config: Arc<Config>,
-    client: Client<ProxyConnector<HttpsConnector<HttpConnector>>>
-) -> Result<Response<Body>,MyStatusCode> {
+    client: SamplyHttpClient
+) -> Result<Response<Body>, MyStatusCode> {
     let targets = &config.targets_public;
     let method = req.method().to_owned();
     let uri = req.uri().to_owned();
@@ -48,7 +49,7 @@ pub(crate) async fn handler_http(
         }
     }
 
-    let target = targets.get(uri.authority().unwrap()) //TODO unwrap
+    let target = &targets.get(uri.authority().unwrap()) //TODO unwrap
         .ok_or(StatusCode::UNAUTHORIZED)?
         .beamconnect;
 
@@ -110,20 +111,24 @@ pub(crate) async fn handler_http(
 
     let bytes = body::to_bytes(resp.body_mut()).await
         .map_err(|_| StatusCode::BAD_GATEWAY)?;
-    let mut body = serde_json::from_slice::<Vec<MsgTaskResult>>(&bytes)
+    let mut task_results = serde_json::from_slice::<Vec<MsgTaskResult>>(&bytes)
         .map_err(|e| {
             warn!("Unable to parse HTTP result: {}", e);
             StatusCode::BAD_GATEWAY
         })?;
-    debug!("Got reply: {:?}", body);
-    if body.len() != 1 {
-        error!("Reply had more than one answer (namely: {}). This should not happen; discarding request.", body.len());
+    debug!("Got reply: {:?}", task_results);
+
+    if task_results.len() != 1 {
+        error!("Reply had more than one answer (namely: {}). This should not happen; discarding request.", task_results.len());
         return Err(StatusCode::BAD_GATEWAY)?;
     }
-    let result = body.drain(0..1).next().unwrap().status;
-    let response_inner = match result {
+    let result = task_results.pop().unwrap();
+    let response_inner = match result.status {
         shared::WorkStatus::Succeeded => {
-            serde_json::from_str::<HttpResponse>(&b)?
+            serde_json::from_str::<HttpResponse>(&result.body.body.ok_or({
+                warn!("Recieved one sucessfull result but it has no body");
+                StatusCode::BAD_GATEWAY
+            })?)?
         },
         e => {
             warn!("Reply had unexpected workresult code: {}", e);
@@ -153,14 +158,14 @@ pub(crate) async fn handler_http(
     Ok(resp)
 }
 
-async fn http_req_to_struct(req: Request<Body>, my_id: &AppId, target_id: &AppId, expire: &u64) -> Result<MsgTaskRequest,MyStatusCode> {
+async fn http_req_to_struct(req: Request<Body>, my_id: &AppId, target_id: &AppId, expire: &u64) -> Result<MsgTaskRequest, MyStatusCode> {
     let method = req.method().clone();
     let url = req.uri().clone();
     let headers = req.headers().clone();
     let body = body::to_bytes(req).await
         .map_err(|e| {
             println!("{e}");
-            MyStatusCode { code: StatusCode::BAD_REQUEST }
+            StatusCode::BAD_REQUEST
     })?;
     let body = String::from_utf8(body.to_vec())?;
 

--- a/src/logic_ask.rs
+++ b/src/logic_ask.rs
@@ -86,6 +86,7 @@ pub(crate) async fn handler_http(
     debug!("Fetching reply from Proxy: {results_uri}");
     let req = Request::builder()
         .header(header::AUTHORIZATION, auth)
+        .header(header::ACCEPT, "application/json")
         .uri(results_uri)
         .body(body::Body::empty()).unwrap();
     let mut resp = client.request(req).await

--- a/src/logic_ask.rs
+++ b/src/logic_ask.rs
@@ -122,7 +122,7 @@ pub(crate) async fn handler_http(
     }
     let result = body.drain(0..1).next().unwrap().status;
     let response_inner = match result {
-        shared::WorkStatus::Succeeded(b) => {
+        shared::WorkStatus::Succeeded => {
             serde_json::from_str::<HttpResponse>(&b)?
         },
         e => {

--- a/src/logic_reply.rs
+++ b/src/logic_reply.rs
@@ -3,11 +3,11 @@ use hyper_proxy::ProxyConnector;
 use hyper_tls::HttpsConnector;
 use log::{info, warn, debug};
 use serde_json::Value;
-use shared::{MsgTaskRequest, MsgTaskResult, MsgId,beam_id::{BeamId,AppId}, WorkStatus, Plain};
+use shared::{MsgTaskRequest, MsgTaskResult, MsgId,beam_id::{BeamId,AppId}, WorkStatus, Plain, http_client::SamplyHttpClient};
 
 use crate::{config::Config, errors::BeamConnectError, msg::{IsValidHttpTask, HttpResponse}};
 
-pub(crate) async fn process_requests(config: Config, client: Client<ProxyConnector<HttpsConnector<HttpConnector>>>) -> Result<(), BeamConnectError> {
+pub(crate) async fn process_requests(config: Config, client: SamplyHttpClient) -> Result<(), BeamConnectError> {
     // Fetch tasks from Proxy
     let msgs = fetch_requests(&config, &client).await?;
 
@@ -20,7 +20,7 @@ pub(crate) async fn process_requests(config: Config, client: Client<ProxyConnect
     Ok(())
 }
 
-async fn send_reply(task: &MsgTaskRequest, config: &Config, client: &Client<ProxyConnector<HttpsConnector<HttpConnector>>>, mut resp: Response<Body>) -> Result<(), BeamConnectError> {
+async fn send_reply(task: &MsgTaskRequest, config: &Config, client: &SamplyHttpClient, mut resp: Response<Body>) -> Result<(), BeamConnectError> {
     let body = body::to_bytes(resp.body_mut()).await
         .map_err(BeamConnectError::FailedToReadTargetsReply)?;
     let http_reply = HttpResponse {
@@ -52,7 +52,7 @@ async fn send_reply(task: &MsgTaskRequest, config: &Config, client: &Client<Prox
     Ok(())
 }
 
-async fn execute_http_task(task: &MsgTaskRequest, config: &Config, client: &Client<ProxyConnector<HttpsConnector<HttpConnector>>>) -> Result<Response<Body>, BeamConnectError> {
+async fn execute_http_task(task: &MsgTaskRequest, config: &Config, client: &SamplyHttpClient) -> Result<Response<Body>, BeamConnectError> {
     let task_req = task.http_request()?;
     info!("{} | {} {}", task.from, task_req.method, task_req.url);
     let target = config.targets_local.get(task_req.url.authority().unwrap()) //TODO unwrap
@@ -82,7 +82,7 @@ async fn execute_http_task(task: &MsgTaskRequest, config: &Config, client: &Clie
     Ok(resp)
 }
 
-async fn fetch_requests(config: &Config, client: &Client<ProxyConnector<HttpsConnector<HttpConnector>>>) -> Result<Vec<MsgTaskRequest>, BeamConnectError> {
+async fn fetch_requests(config: &Config, client: &SamplyHttpClient) -> Result<Vec<MsgTaskRequest>, BeamConnectError> {
     let req_to_proxy = Request::builder()
         .uri(format!("{}v1/tasks?to={}&wait_count=1&filter=todo", config.proxy_url, config.my_app_id))
         .header(header::AUTHORIZATION, config.proxy_auth.clone())

--- a/src/logic_reply.rs
+++ b/src/logic_reply.rs
@@ -3,7 +3,7 @@ use hyper_proxy::ProxyConnector;
 use hyper_tls::HttpsConnector;
 use log::{info, warn, debug};
 use serde_json::Value;
-use shared::{MsgTaskRequest, MsgTaskResult, MsgId,beam_id::{BeamId,AppId}};
+use shared::{MsgTaskRequest, MsgTaskResult, MsgId,beam_id::{BeamId,AppId}, WorkStatus, Plain};
 
 use crate::{config::Config, errors::BeamConnectError, msg::{IsValidHttpTask, HttpResponse}};
 
@@ -33,8 +33,9 @@ async fn send_reply(task: &MsgTaskRequest, config: &Config, client: &Client<Prox
         from: config.my_app_id.clone().into(),
         to: vec![task.from.clone()],
         task: task.id,
-        status: shared::WorkStatus::Succeeded(http_reply),
-        metadata: Value::Null
+        status: WorkStatus::Succeeded,
+        metadata: Value::Null,
+        body: Plain::from(http_reply),
     };
     let req_to_proxy = Request::builder()
         .method("PUT")

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ use hyper::{body, Body, service::{service_fn, make_service_fn}, Request, Respons
 use hyper_proxy::ProxyConnector;
 use hyper_tls::HttpsConnector;
 use log::{info, error, debug, warn};
+use shared::http_client::SamplyHttpClient;
 
 mod msg;
 mod example_targets;
@@ -69,7 +70,7 @@ async fn main() -> Result<(), Box<dyn Error>>{
 async fn handler_http_wrapper(
     req: Request<Body>,
     config: Arc<Config>,
-    client: Client<ProxyConnector<HttpsConnector<HttpConnector>>>
+    client: SamplyHttpClient
 ) -> Result<Response<Body>, Infallible> {
     match logic_ask::handler_http(req, config, client).await {
         Ok(e) => Ok(e),

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,21 +42,19 @@ async fn main() -> Result<(), Box<dyn Error>>{
 
     let config = Arc::new(config.clone());
 
-    let make_service = 
-        make_service_fn(|_conn: &AddrStream| {
-            // let remote_addr = conn.remote_addr();
-            let client = client.clone();
-            let config = config.clone();
-            async {
-                Ok::<_, Infallible>(service_fn(move |req|
-                    handler_http_wrapper(req, config.clone(), client.clone())))
-            }
+    let make_service = make_service_fn(|_conn: &AddrStream| {
+        // let remote_addr = conn.remote_addr();
+        let client = client.clone();
+        let config = config.clone();
+        async {
+            Ok::<_, Infallible>(service_fn(move |req|
+                handler_http_wrapper(req, config.clone(), client.clone())))
+        }
     });
 
-    let server =
-        Server::bind(&listen)
+    let server = Server::bind(&listen)
         .serve(make_service)
-        .with_graceful_shutdown(shutdown_signal());
+        .with_graceful_shutdown(shared::graceful_shutdown::wait_for_signal());
 
     if let Err(e) = server.await {
         eprintln!("server error: {}", e);

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -30,7 +30,7 @@ pub(crate) trait IsValidHttpTask {
 
 impl IsValidHttpTask for MsgTaskRequest {
     fn http_request(&self) -> Result<HttpRequest,BeamConnectError> {
-        let req_struct: HttpRequest = serde_json::from_str(&self.body)?;
+        let req_struct: HttpRequest = serde_json::from_str(self.body.body.as_ref().ok_or(BeamConnectError::ReplyInvalid("MsgTaskRequest had no content.".to_string()))?)?;
         if false { // TODO
             return Err(BeamConnectError::IdNotAuthorizedToAccessUrl(self.from.clone(), req_struct.url));
         }


### PR DESCRIPTION
This adds:
- start script which runs docker-compose (mostly copied from beam)
- test.py which does some very basic tests
- Adds support for `central mapping` to be read from a file not only a url