### PR TITLE
Prevent spam requests from beam connect to beam

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -6,6 +6,8 @@ use thiserror::Error;
 
 #[derive(Error,Debug)]
 pub(crate) enum BeamConnectError {
+    #[error("Regular proxy timout")]
+    ProxyTimeoutError,
     #[error("Proxy rejected our authorization")]
     ProxyRejectedAuthorization,
     #[error("Unable to communicate with Proxy: {0}")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,8 @@ use hyper_tls::HttpsConnector;
 use tracing::{info, error, debug, warn};
 use shared::http_client::SamplyHttpClient;
 
+use crate::errors::BeamConnectError;
+
 mod msg;
 mod example_targets;
 mod config;
@@ -35,7 +37,11 @@ async fn main() -> Result<(), Box<dyn Error>>{
         loop {
             debug!("Waiting for next request ...");
             if let Err(e) = logic_reply::process_requests(config2.clone(), client2.clone()).await {
-                warn!("Error in processing request: {e}. Will continue with the next one.");
+                if let BeamConnectError::ProxyTimeoutError = e {
+                    debug!("{e}");
+                } else {
+                    warn!("Error in processing request: {e}. Will continue with the next one.");
+                }
             }
         }
     });


### PR DESCRIPTION
When there was a `BeamConnectError` when executing a `HttpTask` the error just got logged and we yet again requested the same Task from the broker and in most cases failed for the same reason causing a massive spam of requests and log messages.

I changed it to send a `PermFailed` work status result to the broker if we failed to execute the http task. This way the broker won't give us the same task again.