### PR TITLE
Migrate to beam-lib

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ inherits = "release"
 strip = false
 
 [dependencies]
-shared = { git = "https://github.com/samply/beam", branch="develop" }
+beam-lib = { git = "https://github.com/samply/beam", branch="develop" }
 
 #axum = "0.5.12"
 tokio = { version = "1", features = ["macros","rt-multi-thread","signal"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,8 @@ inherits = "release"
 strip = false
 
 [dependencies]
-beam-lib = { git = "https://github.com/samply/beam", branch="develop" }
+beam-lib = { git = "https://github.com/samply/beam", branch="develop", features = ["strict-ids"] }
+shared = { git = "https://github.com/samply/beam", branch="develop" }
 
 #axum = "0.5.12"
 tokio = { version = "1", features = ["macros","rt-multi-thread","signal"] }
@@ -37,7 +38,7 @@ serde = "*"
 serde_json = "*"
 hyper_serde = "0.13"
 
-clap = {version = "4", features = ["derive"]}
+clap = { version = "4", features = ["derive", "env"] }
 
 thiserror = "*"
 http-serde = "1.1.2"

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 services:
   vault:
-    image: vault
+    image: hashicorp/vault
     ports:
       - 127.0.0.1:8200:8200
     environment:
@@ -37,8 +37,7 @@ services:
     environment:
       BROKER_URL: ${BROKER_URL}
       PROXY_ID: ${PROXY1_ID}
-      APP_0_ID: ${APP1_ID_SHORT}
-      APP_0_KEY: ${APP_KEY}
+      APP_app1_KEY: ${APP_KEY}
       PRIVKEY_FILE: /run/secrets/proxy1.pem
       BIND_ADDR: 0.0.0.0:8081
       RUST_LOG: ${RUST_LOG}
@@ -95,8 +94,7 @@ services:
     environment:
       BROKER_URL: ${BROKER_URL}
       PROXY_ID: ${PROXY2_ID}
-      APP_0_ID: ${APP2_ID_SHORT}
-      APP_0_KEY: ${APP_KEY}
+      APP_app2_KEY: ${APP_KEY}
       PRIVKEY_FILE: /run/secrets/proxy2.pem
       BIND_ADDR: 0.0.0.0:8082
       RUST_LOG: ${RUST_LOG}

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,11 +1,11 @@
-use std::{error::Error, path::PathBuf, fs::{File, read_to_string}, str::FromStr, sync::Arc};
+use std::{error::Error, path::PathBuf, fs::read_to_string, str::FromStr, sync::Arc};
 
 use clap::Parser;
-use hyper::{Uri, http::uri::{Authority, Scheme}};
+use hyper::{Uri, http::uri::Authority};
+use shared::http_client::{SamplyHttpClient, self};
 use tokio_native_tls::{TlsAcceptor, native_tls::{self, Identity}};
-use tracing::info;
 use serde::{Serialize, Deserialize};
-use shared::{beam_id::{AppId, BeamId, app_to_broker_id, BrokerId}, http_client::{SamplyHttpClient, self}};
+use beam_lib::{AppId, set_broker_id};
 
 use crate::{example_targets, errors::BeamConnectError};
 
@@ -40,7 +40,7 @@ struct CliArgs {
     #[clap(long, env, value_parser)]
     proxy_url: Uri,
 
-    /// Your short App ID (e.g. connect1)
+    /// Your App ID (e.g. connect1.proxy1.broker)
     #[clap(long, env, value_parser)]
     app_id: String,
 
@@ -103,7 +103,7 @@ pub(crate) struct Site {
     pub(crate) beamconnect: AppId,
 }
 
-#[derive(Clone,Deserialize,Debug)]
+#[derive(Clone, Deserialize, Debug)]
 pub(crate) struct LocalMapping {
     pub(crate) entries: Vec<LocalMappingEntry>
 }
@@ -119,7 +119,7 @@ impl LocalMapping {
 }
 
 /// Maps an external authority to some internal authority if the requesting App is allowed to
-#[derive(Clone,Deserialize,Debug)]
+#[derive(Clone, Deserialize, Debug)]
 pub(crate) struct LocalMappingEntry {
     #[serde(with = "http_serde::authority", rename="external")]
     pub(crate) needle: Authority, // Host part of URL
@@ -142,7 +142,7 @@ pub(crate) struct Config {
     pub(crate) tls_acceptor: Arc<TlsAcceptor>
 }
 
-fn load_local_targets(broker_id: &BrokerId, local_target_path: &Option<PathBuf>) -> Result<LocalMapping,Box<dyn Error>> {
+fn load_local_targets(broker_id: &str, local_target_path: &Option<PathBuf>) -> Result<LocalMapping,Box<dyn Error>> {
     if let Some(json_file) = local_target_path {
         if json_file.exists() {
             let json_string = std::fs::read_to_string(json_file)?;
@@ -178,13 +178,15 @@ async fn load_public_targets(client: &SamplyHttpClient, url: &PathOrUri) -> Resu
 }
 
 impl Config {
-    pub(crate) async fn load() -> Result<Self,Box<dyn Error>> {
+    pub(crate) async fn load() -> Result<Self, Box<dyn Error>> {
         let args = CliArgs::parse();
-        let broker_id = app_to_broker_id(&args.app_id)?;
-        AppId::set_broker_id(broker_id.clone());
-        let my_app_id = AppId::new(&args.app_id)?;
-        let broker_id = BrokerId::new(&broker_id)?;
-
+        let broker_id = args.app_id
+            .splitn(3, '.')
+            .last()
+            .ok_or_else(|| BeamConnectError::ConfigurationError(format!("Invalid beam id: {}", args.app_id)))?;
+        set_broker_id(broker_id.to_owned());
+        let app_id = AppId::new(&args.app_id)?;
+    
         let expire = args.expire;
 
         let tls_ca_certificates = shared::crypto::load_certificates_from_dir(args.tls_ca_certificates_dir)?;
@@ -204,8 +206,8 @@ impl Config {
 
         Ok(Config {
             proxy_url: args.proxy_url,
-            my_app_id: my_app_id.clone(),
-            proxy_auth: format!("ApiKey {} {}", my_app_id, args.proxy_apikey),
+            my_app_id: app_id.clone(),
+            proxy_auth: format!("ApiKey {} {}", app_id, args.proxy_apikey),
             bind_addr: args.bind_addr,
             targets_local,
             targets_public,
@@ -218,10 +220,11 @@ impl Config {
 
 #[cfg(test)]
 mod tests {
+    use beam_lib::set_broker_id;
+
     use super::CentralMapping;
     use super::LocalMapping;
     use crate::example_targets::example_local;
-    use beam-lib::{BrokerId,BeamId,app_to_broker_id};
 
     #[test]
     fn serde_authority() {
@@ -253,6 +256,7 @@ mod tests {
               }
             ]
           }"#;
+        set_broker_id("broker.ccp-it.dktk.dkfz.de".to_owned());
         let obj: CentralMapping = serde_json::from_str(serialized).unwrap();
         assert_eq!(obj.sites.len(), 4);
         let mut routes = obj.sites.iter();
@@ -268,14 +272,13 @@ mod tests {
 
     #[test]
     fn local_target_configuration() {
-        let broker_id = app_to_broker_id("foo.bar.broker.example").unwrap();
-        BrokerId::set_broker_id(broker_id.clone());
-        let broker_id = BrokerId::new(&broker_id).unwrap();
+        let broker_id = "broker.ccp-it.dktk.dkfz.de"; 
+        set_broker_id(broker_id.to_owned());
         let serialized = r#"[
-            {"external": "ifconfig.me","internal":"ifconfig.me","allowed":["connect1.proxy23.broker.example","connect2.proxy23.broker.example"]},
-            {"external": "ip-api.com","internal":"ip-api.com","allowed":["connect1.proxy23.broker.example","connect2.proxy23.broker.example"]},
-            {"external": "wttr.in","internal":"wttr.in","allowed":["connect1.proxy23.broker.example","connect2.proxy23.broker.example"]},
-            {"external": "node23.uk12.network","internal":"host23.internal.network","allowed":["connect1.proxy23.broker.example","connect2.proxy23.broker.example"]}
+            {"external": "ifconfig.me","internal":"ifconfig.me","allowed":["connect1.proxy23.broker.ccp-it.dktk.dkfz.de","connect2.proxy23.broker.ccp-it.dktk.dkfz.de"]},
+            {"external": "ip-api.com","internal":"ip-api.com","allowed":["connect1.proxy23.broker.ccp-it.dktk.dkfz.de","connect2.proxy23.broker.ccp-it.dktk.dkfz.de"]},
+            {"external": "wttr.in","internal":"wttr.in","allowed":["connect1.proxy23.broker.ccp-it.dktk.dkfz.de","connect2.proxy23.broker.ccp-it.dktk.dkfz.de"]},
+            {"external": "node23.uk12.network","internal":"host23.internal.network","allowed":["connect1.proxy23.broker.ccp-it.dktk.dkfz.de","connect2.proxy23.broker.ccp-it.dktk.dkfz.de"]}
         ]"#;
         let obj: LocalMapping = LocalMapping{entries:serde_json::from_str(serialized).unwrap()};
         let expect = example_local(&broker_id);

--- a/src/config.rs
+++ b/src/config.rs
@@ -221,7 +221,7 @@ mod tests {
     use super::CentralMapping;
     use super::LocalMapping;
     use crate::example_targets::example_local;
-    use shared::beam_id::{BrokerId,BeamId,app_to_broker_id};
+    use beam-lib::{BrokerId,BeamId,app_to_broker_id};
 
     #[test]
     fn serde_authority() {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,7 +1,7 @@
 use std::{str::Utf8Error, string::FromUtf8Error};
 
 use hyper::Uri;
-use shared::beam_id::AppOrProxyId;
+use beam-lib::AppOrProxyId;
 use thiserror::Error;
 
 #[derive(Error,Debug)]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,7 +1,7 @@
-use std::{str::Utf8Error, string::FromUtf8Error};
+use std::string::FromUtf8Error;
 
 use hyper::Uri;
-use beam-lib::AppOrProxyId;
+use beam_lib::AppOrProxyId;
 use thiserror::Error;
 
 #[derive(Error,Debug)]

--- a/src/example_targets.rs
+++ b/src/example_targets.rs
@@ -1,5 +1,5 @@
 use hyper::http::uri::Authority;
-use shared::beam_id::{AppId, BeamId, BrokerId, ProxyId};
+use beam-lib::{AppId, BeamId, BrokerId, ProxyId};
 
 use crate::config::{CentralMapping, LocalMapping, LocalMappingEntry};
 

--- a/src/example_targets.rs
+++ b/src/example_targets.rs
@@ -1,9 +1,9 @@
 use hyper::http::uri::Authority;
-use beam-lib::{AppId, BeamId, BrokerId, ProxyId};
+use beam_lib::{AppId, ProxyId};
 
-use crate::config::{CentralMapping, LocalMapping, LocalMappingEntry};
+use crate::config::{LocalMapping, LocalMappingEntry};
 
-pub(crate) fn example_local(broker_id: &BrokerId) -> LocalMapping {
+pub(crate) fn example_local(broker_id: &str) -> LocalMapping {
     let proxy23 = ProxyId::new(&format!("proxy23.{}", broker_id)).unwrap();
     let app1_id = AppId::new(&format!("connect1.{}",proxy23)).unwrap();
     let app2_id = AppId::new(&format!("connect2.{}",proxy23)).unwrap();

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -15,7 +15,7 @@ pub(crate) struct HttpRequest {
     pub(crate) body: Vec<u8>
 }
 
-#[derive(Serialize,Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct HttpResponse {
     #[serde(with = "hyper_serde")]
     pub(crate) status: StatusCode,


### PR DESCRIPTION
I could not remove beam shared yet sadly as the http client builder from shared is still very useful here. We could maybe integrate the client as part of a beam-lib feature, but it needs a lot of dependencies (which would be behind the flag but still) and really has nothing to do with beam. So to get rid of it here I would suggest to either paste a minimal version of the client into beam connect or maybe write some extra crate that lets you configure a proper http client with feature flags i.e proxy support, tls.