### PR TITLE
Refactor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,18 +26,17 @@ tower-http = { version = "0", features = ["trace"] }
 tower = "*"
 
 # HTTP client with proxy support
-reqwest = { version = "0.11.19", features = ["json"] }
+reqwest = { version = "0.11.19", features = ["json", "stream"] }
 
 tracing = "0.1.35"
 
 serde = "*"
 serde_json = "*"
-hyper_serde = "0.13"
 
 clap = { version = "4", features = ["derive", "env"] }
 
 thiserror = "*"
-http-serde = "1.1.2"
+http-serde = "1.1"
 tokio-native-tls = "0.3.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 anyhow = "1"
@@ -52,4 +51,4 @@ build-data = "0"
 [dev-dependencies]
 futures-util = "0.3.28"
 paste = "1.0.12"
-tokio-tungstenite = "0.19.0"
+tokio-tungstenite = "0.20.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,7 @@ strip = false
 
 [dependencies]
 beam-lib = { git = "https://github.com/samply/beam", branch="develop", features = ["strict-ids"] }
-shared = { git = "https://github.com/samply/beam", branch="develop" }
 
-#axum = "0.5.12"
 tokio = { version = "1", features = ["macros","rt-multi-thread","signal"] }
 hyper = { version = "0.14", features = ["full"] }
 tower-http = { version = "0", features = ["trace"] }
@@ -43,6 +41,10 @@ clap = { version = "4", features = ["derive", "env"] }
 thiserror = "*"
 http-serde = "1.1.2"
 tokio-native-tls = "0.3.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+reqwest = { version = "0.11.19", features = ["json"] }
+anyhow = "1"
+openssl = "*" # Already used by native_tls which does not reexport it. This is used for b64 en/decode
 
 [features]
 sockets = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,13 +22,11 @@ beam-lib = { git = "https://github.com/samply/beam", branch="develop", features 
 
 tokio = { version = "1", features = ["macros","rt-multi-thread","signal"] }
 hyper = { version = "0.14", features = ["full"] }
-tower-http = { version = "0", features = ["trace"] }
-tower = "*"
 
 # HTTP client with proxy support
 reqwest = { version = "0.11.19", features = ["json", "stream"] }
 
-tracing = "0.1.35"
+tracing = "0.1"
 
 serde = "*"
 serde_json = "*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,9 +26,7 @@ tower-http = { version = "0", features = ["trace"] }
 tower = "*"
 
 # HTTP client with proxy support
-hyper-tls = "0.5.0"
-hyper-proxy = "0.9.1"
-mz-http-proxy = { version = "0.1.0", features = ["hyper"] }
+reqwest = { version = "0.11.19", features = ["json"] }
 
 tracing = "0.1.35"
 
@@ -42,7 +40,6 @@ thiserror = "*"
 http-serde = "1.1.2"
 tokio-native-tls = "0.3.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-reqwest = { version = "0.11.19", features = ["json"] }
 anyhow = "1"
 openssl = "*" # Already used by native_tls which does not reexport it. This is used for b64 en/decode
 

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -52,7 +52,6 @@ services:
     build:
       context: ../
       dockerfile: Dockerfile.ci
-    image: samply/beam-connect:${TAG}
     ports:
       - 8062:8062
     volumes:
@@ -71,7 +70,6 @@ services:
    build:
      context: ../
      dockerfile: Dockerfile.ci
-   image: samply/beam-connect:${TAG}
    ports:
      - 8063:8063
    volumes:

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -11,7 +11,7 @@ pub(crate) enum BeamConnectError {
     #[error("Proxy rejected our authorization")]
     ProxyRejectedAuthorization,
     #[error("Unable to communicate with Proxy: {0}")]
-    ProxyHyperError(hyper::Error),
+    ProxyReqwestError(reqwest::Error),
     #[error("Unable to communicate with Proxy: {0}")]
     ProxyOtherError(String),
     #[error("Constructing HTTP request failed: {0}")]
@@ -23,7 +23,7 @@ pub(crate) enum BeamConnectError {
     #[error("Unable to communicate with target host: {0}")]
     CommunicationWithTargetFailed(String),
     #[error("Unable to fetch reply from target host: {0}")]
-    FailedToReadTargetsReply(hyper::Error),
+    FailedToReadTargetsReply(reqwest::Error),
     #[error("Response was not valid UTF-8: {0}")]
     ResponseNotValidUtf8String(#[from] FromUtf8Error),
     #[error("Reply invalid: {0}")]

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -3,11 +3,11 @@ use serde::{Serialize, Deserialize};
 
 #[derive(Serialize,Deserialize, Debug)]
 pub(crate) struct HttpRequest {
-    #[serde(with = "hyper_serde")]
+    #[serde(with = "http_serde::method")]
     pub(crate) method: Method,
-    #[serde(with = "hyper_serde")]
+    #[serde(with = "http_serde::uri")]
     pub(crate) url: Uri,
-    #[serde(with = "hyper_serde")]
+    #[serde(with = "http_serde::header_map")]
     pub(crate) headers: HeaderMap,
     #[serde(with = "serde_base64")]
     pub(crate) body: Vec<u8>
@@ -15,9 +15,9 @@ pub(crate) struct HttpRequest {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct HttpResponse {
-    #[serde(with = "hyper_serde")]
+    #[serde(with = "http_serde::status_code")]
     pub(crate) status: StatusCode,
-    #[serde(with = "hyper_serde")]
+    #[serde(with = "http_serde::header_map")]
     pub(crate) headers: HeaderMap,
     #[serde(with = "serde_base64")]
     pub(crate) body: Vec<u8>

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -1,7 +1,5 @@
 use hyper::{Method, Uri, HeaderMap, StatusCode};
 use serde::{Serialize, Deserialize};
-use shared::MsgTaskRequest;
-use crate::errors::BeamConnectError;
 
 #[derive(Serialize,Deserialize, Debug)]
 pub(crate) struct HttpRequest {
@@ -11,7 +9,7 @@ pub(crate) struct HttpRequest {
     pub(crate) url: Uri,
     #[serde(with = "hyper_serde")]
     pub(crate) headers: HeaderMap,
-    #[serde(with = "shared::serde_helpers::serde_base64")]
+    #[serde(with = "serde_base64")]
     pub(crate) body: Vec<u8>
 }
 
@@ -21,20 +19,25 @@ pub(crate) struct HttpResponse {
     pub(crate) status: StatusCode,
     #[serde(with = "hyper_serde")]
     pub(crate) headers: HeaderMap,
-    #[serde(with = "shared::serde_helpers::serde_base64")]
+    #[serde(with = "serde_base64")]
     pub(crate) body: Vec<u8>
 }
 
-pub(crate) trait IsValidHttpTask {
-    fn http_request(&self) -> Result<HttpRequest,BeamConnectError>;
-}
 
-impl IsValidHttpTask for MsgTaskRequest {
-    fn http_request(&self) -> Result<HttpRequest,BeamConnectError> {
-        let req_struct: HttpRequest = serde_json::from_str(self.body.body.as_ref().ok_or(BeamConnectError::ReplyInvalid("MsgTaskRequest had no content.".to_string()))?)?;
-        if false { // TODO
-            return Err(BeamConnectError::IdNotAuthorizedToAccessUrl(self.from.clone(), req_struct.url));
-        }
-        Ok(req_struct)
+// https://github.com/serde-rs/json/issues/360#issuecomment-330095360
+pub mod serde_base64 {
+    use serde::{Serializer, de, Deserialize, Deserializer};
+    use openssl::base64;
+
+    pub fn serialize<S>(bytes: &[u8], serializer: S) -> Result<S::Ok, S::Error>
+        where S: Serializer
+    {
+        serializer.serialize_str(&base64::encode_block(bytes))
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
+        where D: Deserializer<'de>
+    {
+        base64::decode_block(<&str>::deserialize(deserializer)?).map_err(de::Error::custom)
     }
 }

--- a/src/shutdown.rs
+++ b/src/shutdown.rs
@@ -1,0 +1,25 @@
+use tracing::info;
+
+#[cfg(unix)]
+pub async fn wait_for_signal() {
+    use tokio::signal::unix::{signal, SignalKind};
+    let mut sigterm = signal(SignalKind::terminate())
+        .expect("Unable to register shutdown handler; are you running a Unix-based OS?");
+    let mut sigint = signal(SignalKind::interrupt())
+        .expect("Unable to register shutdown handler; are you running a Unix-based OS?");
+    let signal = tokio::select! {
+        _ = sigterm.recv() => "SIGTERM",
+        _ = sigint.recv() => "SIGINT"
+    };
+    // The following does not print in docker-compose setups but it does when run individually.
+    // Probably a docker-compose error.
+    info!("Received signal ({signal}) - shutting down gracefully.");
+}
+
+#[cfg(windows)]
+pub async fn wait_for_signal() {
+    if let Err(e) = tokio::signal::ctrl_c().await {
+        panic!("Unable to register shutdown handler: {e}.");
+    }
+    info!("Received shutdown signal - shutting down gracefully.");
+}

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -1,8 +1,6 @@
 use std::{string::FromUtf8Error, error::Error, fmt::Display};
 
-use hyper::{StatusCode, header::ToStrError, http::uri::Authority};
-use tracing::error;
-use shared::errors::SamplyBeamError;
+use hyper::{StatusCode, header::ToStrError};
 
 #[derive(Debug)]
 pub(crate) struct MyStatusCode {
@@ -24,19 +22,6 @@ impl From<ToStrError> for MyStatusCode {
 impl From<MyStatusCode> for StatusCode {
     fn from(e: MyStatusCode) -> Self {
         e.code
-    }
-}
-
-impl From<SamplyBeamError> for MyStatusCode {
-    fn from(e: SamplyBeamError) -> Self {
-        let code = match e {
-            SamplyBeamError::InvalidBeamId(e) => {
-                error!("{e}");
-                StatusCode::BAD_REQUEST
-            },
-            _ => StatusCode::NOT_IMPLEMENTED,
-        };
-        Self { code }
     }
 }
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,27 +1,20 @@
 
 use clap::__derive_refs::once_cell::sync::Lazy;
-use hyper::{Response, Body, Request, header, http::HeaderValue, Client, client::HttpConnector};
-use hyper_proxy::{Proxy, Intercept, ProxyConnector};
-use hyper_tls::HttpsConnector;
-use tokio_native_tls::native_tls::TlsConnector;
+use hyper::{header, http::HeaderValue, HeaderMap};
+use reqwest::{Client, Proxy};
 
-const CLIENT: Lazy<Client<ProxyConnector<HttpsConnector<HttpConnector>>>> = Lazy::new(|| {
-    let tls = TlsConnector::builder()
+pub static TEST_CLIENT: Lazy<Client> = Lazy::new(|| {
+    Client::builder()
         .danger_accept_invalid_certs(true)
-        .danger_accept_invalid_hostnames(true)
+        .proxy(Proxy::all("http://localhost:8062").unwrap())
+        .default_headers({
+            let mut headers = HeaderMap::new();
+            headers.append(header::PROXY_AUTHORIZATION, HeaderValue::from_static("ApiKey app1.proxy1.broker App1Secret"));
+            headers
+        })
         .build()
-        .unwrap();
-    let connector = HttpsConnector::from((HttpConnector::new(), tls.clone().into()));
-    let proxy = Proxy::new(Intercept::All, "http://localhost:8062".parse().unwrap());
-    let mut proxy_con = ProxyConnector::from_proxy(connector, proxy).unwrap();
-    proxy_con.set_tls(Some(tls));
-    Client::builder().build(proxy_con)
+        .unwrap()
 });
-
-pub async fn request(mut req: Request<Body>) -> Response<Body> {
-    req.headers_mut().append(header::PROXY_AUTHORIZATION, HeaderValue::from_static("ApiKey app1.proxy1.broker App1Secret"));
-    CLIENT.request(req).await.unwrap()
-}
 
 #[macro_export]
 macro_rules! test_http_and_https {


### PR DESCRIPTION
This PR removes a lot of dependencies by getting rid of beam_shared and updating everything to use reqwest instead of a hyper::Client with a bunch of connectors which came from outdated crates.
This reduced the dependencies from 300 to 163!

Before this gets merged we should test if `HTTP(S)_PROXY`, `ALL_PROXY` and `NO_PROXY` still work as they did before.