### PR TITLE
Fix/parse host

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ anyhow = "1"
 openssl = "*" # Already used by native_tls which does not reexport it. This is used for b64 en/decode
 
 [features]
-sockets = []
+sockets = ["beam-lib/sockets"]
 
 [build-dependencies]
 build-data = "0"

--- a/src/logic_ask.rs
+++ b/src/logic_ask.rs
@@ -26,7 +26,7 @@ pub(crate) async fn handler_http(
     let authority = https_authority
         .as_ref()
         .or(uri.authority());
-    if authority.is_none() && uri.path() == "/site" {
+    if authority.is_none() && uri.path() == "/sites" {
             // Case 1 for sites request: no authority set and /sites
             return respond_with_sites(targets)
     }


### PR DESCRIPTION
Some HTTP-Clients (such as the DNPM Node) do not fully comply with the HTTP-Proxy standard, leading to potentially empty `authority` parts, while the intended authority is (only) encoded in the `host` header field.
This PR looks into the `host` header field for an authority, if:
1. the request authority is `None`
2. Additionally, the path is not `/sites`

This should restore the intended functionality with minimal change.

The following changes are necessary before merging:
- [x] change path to `/sites` in `src_logic_ask.rs:29`