### PR TITLE
feat: execute tasks in batches

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ tokio = { version = "1", features = ["macros","rt-multi-thread","signal"] }
 hyper = { version = "1", features = ["full"] }
 hyper-util = { version = "0.1", features = ["server-graceful", "server-auto"]}
 http-body-util = { version = "0.1" }
-futures-util = { version = "0.3", optional = true, default-features = false }
+futures-util = { version = "0.3", default-features = false }
 
 # HTTP client with proxy support
 reqwest = { version = "0.12", features = ["json", "stream"] }
@@ -44,7 +44,7 @@ anyhow = "1"
 openssl = "*" # Already used by native_tls which does not reexport it. This is used for b64 en/decode
 
 [features]
-sockets = ["beam-lib/sockets", "dep:futures-util"]
+sockets = ["beam-lib/sockets"]
 
 [build-dependencies]
 build-data = "0.2"

--- a/src/logic_reply.rs
+++ b/src/logic_reply.rs
@@ -1,6 +1,7 @@
 use std::{pin::pin, sync::Arc};
 
 use beam_lib::{AppOrProxyId, TaskRequest, TaskResult, WorkStatus};
+use futures_util::future::TryJoinAll;
 use hyper::{header, StatusCode, Uri, Method, http::uri::PathAndQuery};
 use tracing::{debug, field, info, trace, warn, Instrument, Span};
 use serde_json::Value;
@@ -9,10 +10,13 @@ use reqwest::Response;
 use crate::{config::Config, errors::BeamConnectError, msg::{HttpResponse, HttpRequest}};
 
 pub(crate) async fn process_requests(config: &'static Config) -> Result<(), BeamConnectError> {
-    // Fetch tasks from Proxy
-    let task = fetch_task(&config).await?;
-    claim_or_answer(task, &config).await?;
-
+    // Fetch a batch of tasks and executed them in parallel
+    fetch_task(&config)
+        .await?
+        .into_iter()
+        .map(|task| claim_or_answer(task, config))
+        .collect::<TryJoinAll<_>>()
+        .await?;
     Ok(())
 }
 
@@ -169,7 +173,7 @@ async fn execute_http_task(task: &TaskRequest<HttpRequest>, config: &Config) -> 
     Ok(resp)
 }
 
-async fn fetch_task(config: &Config) -> Result<TaskRequest<HttpRequest>, BeamConnectError> {
+async fn fetch_task(config: &Config) -> Result<Vec<TaskRequest<HttpRequest>>, BeamConnectError> {
     debug!("fetching requests from proxy");
     let resp = config.client
         .get(format!("{}v1/tasks?to={}&wait_count=1&filter=todo", config.proxy_url, config.my_app_id))
@@ -191,5 +195,5 @@ async fn fetch_task(config: &Config) -> Result<TaskRequest<HttpRequest>, BeamCon
     resp.json::<Vec<TaskRequest<HttpRequest>>>().await.map_err(|e| {
         warn!("Unable to decode TaskRequest<HttpRequest>; error: {e}.");
         BeamConnectError::ProxyOtherError(e.to_string())
-    })?.pop().ok_or(BeamConnectError::ProxyTimeoutError)
+    }).map_err(Into::into)
 }


### PR DESCRIPTION
My first benchmarks using [oha](https://github.com/hatoo/oha) show that this leads to a 25x performance improvement 🚀 

```bash
oha -x http://localhost:8062 -H "proxy-authorization: ApiKey app1.proxy1.broker App1Secret" http://echo-get/foo --no-pre-lookup
```

The idea came to mind when I saw this https://github.com/samply/beam/pull/225