### PR TITLE
fix: don't count regular timeouts with weird status codes as failed requests

### DIFF
--- a/src/logic_reply.rs
+++ b/src/logic_reply.rs
@@ -1,4 +1,4 @@
-use std::{pin::pin, sync::Arc};
+use std::{pin::pin, sync::Arc, time::Duration};
 
 use beam_lib::{AppOrProxyId, TaskRequest, TaskResult, WorkStatus};
 use futures_util::future::TryJoinAll;
@@ -174,6 +174,7 @@ async fn execute_http_task(task: &TaskRequest<HttpRequest>, config: &Config) -> 
 
 async fn fetch_task(config: &Config) -> Result<Vec<TaskRequest<HttpRequest>>, BeamConnectError> {
     debug!("fetching requests from proxy");
+    let probably_timeout = tokio::time::sleep(Duration::from_secs(20));
     let resp = config.client
         .get(format!("{}v1/tasks?to={}&wait_count=1&filter=todo", config.proxy_url, config.my_app_id))
         .header(header::AUTHORIZATION, config.proxy_auth.clone())
@@ -182,11 +183,15 @@ async fn fetch_task(config: &Config) -> Result<Vec<TaskRequest<HttpRequest>>, Be
         .await
         .map_err(BeamConnectError::ProxyReqwestError)?;
     match resp.status() {
-        StatusCode::OK => {
+        StatusCode::OK | StatusCode::PARTIAL_CONTENT => {
             trace!("Got tasks from beam: {resp:#?}");
         },
         StatusCode::GATEWAY_TIMEOUT => return Err(BeamConnectError::ProxyTimeoutError),
         StatusCode::UNAUTHORIZED => return Err(BeamConnectError::ProxyRejectedAuthorization),
+        s if probably_timeout.is_elapsed() => {
+            debug!("Request to proxy timed out with StatusCode {s}");
+            return Err(BeamConnectError::ProxyTimeoutError)
+        },
         _ => {
             return Err(BeamConnectError::ProxyOtherError(format!("Got response code {}", resp.status())));
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,9 +46,7 @@ async fn main() -> anyhow::Result<()> {
             debug!("Waiting for next request ...");
             if let Err(e) = logic_reply::process_requests(config).await {
                 match e {
-                    BeamConnectError::ProxyTimeoutError => {
-                        debug!("{e}");
-                    },
+                    BeamConnectError::ProxyTimeoutError => (),
                     BeamConnectError::ProxyRejectedAuthorization => {
                         error!("Stopping task polling: {e}");
                         break
@@ -58,7 +56,6 @@ async fn main() -> anyhow::Result<()> {
                         warn!("Error in processing request: {e}. Will continue with the next one.");
                     },
                     _ => {
-                        tries += 1;
                         warn!("Failed to process requests: {e}. Retrying in 30s.");
                         tokio::time::sleep(Duration::from_secs(30)).await;
                     }


### PR DESCRIPTION
Motivation for this is that we get 502s pretty much every time if there is no tasks. And we don't really want to log that as an error message which we would not even do if the retry thing I build would be faster at decrementing the counter which I also think I fixed here.
The worst part about this issue is that we used to sleep for 30s in these cases which made it unresponsive.