### PR TITLE
Support raw http CONNECT when using beam sockets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 dev/pki/*
 !dev/pki/pki
 artifacts/
+.zed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "beam-connect"
 version = "0.2.0"
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,17 +8,13 @@ ARG TARGETARCH
 COPY /artifacts/binaries-$TARGETARCH$FEATURE/beam-connect /app/
 RUN chmod +x /app/*
 
-# FROM ${IMGNAME}
 FROM ubuntu:latest
 RUN apt update
-RUN apt install -y ca-certificates
-RUN apt install -y ssl-cert
-RUN make-ssl-cert generate-default-snakeoil
-#ARG COMPONENT
-ARG TARGETARCH
-#COPY /artifacts/binaries-$TARGETARCH/$COMPONENT /usr/local/bin/
-COPY --from=chmodder /app/* /usr/local/bin/
-#ENTRYPOINT [ "/usr/local/bin/$COMPONENT" ]
-ENTRYPOINT [ "/usr/local/bin/beam-connect" ]
-# ENTRYPOINT ["tail", "-f", "/dev/null"]
+RUN apt install -y ca-certificates ssl-cert
 
+RUN make-ssl-cert generate-default-snakeoil
+ENV SSL_CERT_PEM=/etc/ssl/certs/ssl-cert-snakeoil.pem
+ENV SSL_CERT_KEY=/etc/ssl/private/ssl-cert-snakeoil.key
+
+COPY --from=chmodder /app/* /usr/local/bin/
+ENTRYPOINT [ "/usr/local/bin/beam-connect" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,8 @@ RUN apt update
 RUN apt install -y ca-certificates ssl-cert
 
 RUN make-ssl-cert generate-default-snakeoil
-ENV SSL_CERT_PEM=/etc/ssl/certs/ssl-cert-snakeoil.pem
-ENV SSL_CERT_KEY=/etc/ssl/private/ssl-cert-snakeoil.key
+ENV TLS_TERMINATION_CERT_PATH=/etc/ssl/certs/ssl-cert-snakeoil.pem
+ENV TLS_TERMINATION_KEY_PATH=/etc/ssl/private/ssl-cert-snakeoil.key
 
 COPY --from=chmodder /app/* /usr/local/bin/
 ENTRYPOINT [ "/usr/local/bin/beam-connect" ]

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -80,8 +80,8 @@ services:
      RUST_LOG: ${RUST_LOG}
      no_proxy: proxy2,my.example.com
      TLS_CA_CERTIFICATES_DIR: /custom-cert
-     SSL_CERT_PEM: ""
-     SSL_CERT_KEY: ""
+     TLS_TERMINATION_CERT_PATH: ""
+     TLS_TERMINATION_KEY_PATH: ""
   proxy2:
     depends_on: [broker]
     image: samply/beam-proxy:${TAG}

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -80,6 +80,8 @@ services:
      RUST_LOG: ${RUST_LOG}
      no_proxy: proxy2,my.example.com
      TLS_CA_CERTIFICATES_DIR: /custom-cert
+     SSL_CERT_PEM: ""
+     SSL_CERT_KEY: ""
   proxy2:
     depends_on: [broker]
     image: samply/beam-proxy:${TAG}

--- a/examples/example_local_test.json
+++ b/examples/example_local_test.json
@@ -12,7 +12,7 @@
     {
         "external": "echo-get:443",
         "internal": "my.example.com:443/get",
-        "allowed": ["app1.proxy1.broker"]
+        "allowed": ["app1.proxy1.broker", "app2.proxy2.broker"]
     },
     {
         "external": "echo-allowed",

--- a/src/banner.rs
+++ b/src/banner.rs
@@ -4,14 +4,25 @@ pub fn print_banner() {
     let commit = match env!("GIT_DIRTY") {
         "false" => {
             env!("GIT_COMMIT_SHORT")
-        },
-        _ => {
-            "SNAPSHOT"
         }
+        _ => "SNAPSHOT",
     };
-    info!("🌈 Samply.Connect ({}) v{} (built {} {}, {}) starting up ...", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"), env!("BUILD_DATE"), env!("BUILD_TIME"), commit);
+    info!(
+        "🌈 Samply.Connect ({}) v{} (built {} {}, {}) starting up ...",
+        env!("CARGO_PKG_NAME"),
+        env!("CARGO_PKG_VERSION"),
+        env!("BUILD_DATE"),
+        env!("BUILD_TIME"),
+        commit
+    );
 }
 
 pub(crate) fn print_startup_app_config(config: &crate::Config) {
-    info!("Communicating with Proxy {} using AppId {}. There are {} entries in the local and {} entries in the central target configuration.", config.proxy_url, config.my_app_id, config.targets_local.entries.len(), config.targets_public.sites.len());
+    info!(
+        "Communicating with Proxy {} using AppId {}. There are {} entries in the local and {} entries in the central target configuration.",
+        config.proxy_url,
+        config.my_app_id,
+        config.targets_local.entries.len(),
+        config.targets_public.sites.len()
+    );
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,16 +1,24 @@
-use std::{path::PathBuf, fs::{read_to_string, self}, str::FromStr, sync::Arc};
+use std::{
+    fs::{self, read_to_string},
+    path::PathBuf,
+    str::FromStr,
+    sync::Arc,
+};
 
 use anyhow::Result;
+use beam_lib::{AppId, AppOrProxyId, set_broker_id};
 use clap::Parser;
 use hyper::{Uri, http::uri::Authority};
 use regex::Regex;
 use reqwest::{Certificate, Client};
-use tokio_native_tls::{TlsAcceptor, native_tls::{self, Identity}};
-use serde::{Serialize, Deserialize};
-use beam_lib::{set_broker_id, AppId, AppOrProxyId};
+use serde::{Deserialize, Serialize};
+use tokio_native_tls::{
+    TlsAcceptor,
+    native_tls::{self, Identity},
+};
 use tracing::warn;
 
-use crate::{example_targets, errors::BeamConnectError};
+use crate::{errors::BeamConnectError, example_targets};
 
 #[derive(Debug, Clone)]
 enum PathOrUri {
@@ -29,7 +37,9 @@ impl FromStr for PathOrUri {
                 if p.is_file() {
                     Ok(Self::Path(p))
                 } else {
-                    Err(BeamConnectError::ConfigurationError(format!("Failed to convert {s} to Filepath or Uri")))
+                    Err(BeamConnectError::ConfigurationError(format!(
+                        "Failed to convert {s} to Filepath or Uri"
+                    )))
                 }
             }
         }
@@ -37,7 +47,7 @@ impl FromStr for PathOrUri {
 }
 
 /// Settings for Samply.Beam (Shared)
-#[derive(Parser,Debug)]
+#[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None)]
 struct CliArgs {
     #[clap(long, env, value_parser)]
@@ -68,11 +78,21 @@ struct CliArgs {
     tls_ca_certificates_dir: Option<PathBuf>,
 
     /// Pem file used for ssl support. Will use a snakeoil pem if unset.
-    #[clap(long, env, value_parser, default_value = "/etc/ssl/certs/ssl-cert-snakeoil.pem")]
+    #[clap(
+        long,
+        env,
+        value_parser,
+        default_value = "/etc/ssl/certs/ssl-cert-snakeoil.pem"
+    )]
     ssl_cert_pem: PathBuf,
 
     /// Key file used for ssl support. Will use a snakeoil key if unset.
-    #[clap(long, env, value_parser, default_value = "/etc/ssl/private/ssl-cert-snakeoil.key")]
+    #[clap(
+        long,
+        env,
+        value_parser,
+        default_value = "/etc/ssl/private/ssl-cert-snakeoil.key"
+    )]
     ssl_cert_key: PathBuf,
 
     /// Expiry time of the request in seconds
@@ -85,19 +105,19 @@ struct CliArgs {
     no_auth: bool,
 }
 
-#[derive(Serialize, Deserialize,Clone,Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub(crate) struct CentralMapping {
-    pub(crate) sites: Vec<Site>
+    pub(crate) sites: Vec<Site>,
 }
 
 impl CentralMapping {
     pub(crate) fn get(&self, auth: &Authority) -> Option<&Site> {
         for site in &self.sites {
             if site.virtualhost == *auth {
-                return Some(site)
+                return Some(site);
             }
         }
-        return None
+        return None;
     }
 }
 
@@ -113,32 +133,41 @@ pub(crate) struct Site {
 
 #[derive(Clone, Deserialize, Debug)]
 pub(crate) struct LocalMapping {
-    pub(crate) entries: Vec<LocalMappingEntry>
+    pub(crate) entries: Vec<LocalMappingEntry>,
 }
 impl LocalMapping {
     pub(crate) fn get(&self, uri: &Uri) -> Option<LocalMappingEntry> {
         for entry in &self.entries {
-            if Some(&entry.needle) == uri.authority() && entry.external_path.as_ref().map_or(true, |r| r.is_match(uri.path())) {
-                return Some(entry.clone())
+            if Some(&entry.needle) == uri.authority()
+                && entry
+                    .external_path
+                    .as_ref()
+                    .map_or(true, |r| r.is_match(uri.path()))
+            {
+                return Some(entry.clone());
             }
         }
-        return None
+        return None;
     }
 }
 
 /// Maps an external authority to some internal authority if the requesting App is allowed to
 #[derive(Clone, Deserialize, Debug)]
 pub(crate) struct LocalMappingEntry {
-    #[serde(with = "http_serde::authority", rename="external")]
+    #[serde(with = "http_serde::authority", rename = "external")]
     pub(crate) needle: Authority, // Host part of URL
-    #[serde(rename="internal")]
+    #[serde(rename = "internal")]
     pub(crate) replace: AuthorityReplacement,
     pub(crate) allowed: Vec<AppOrProxyId>,
     #[serde(default, rename = "forceHttps")]
     pub(crate) force_https: bool,
     #[serde(default, rename = "resetHost")]
     pub(crate) reset_host: bool,
-    #[serde(default, rename = "externalPathRegex", deserialize_with = "deserialize_regex")]
+    #[serde(
+        default,
+        rename = "externalPathRegex",
+        deserialize_with = "deserialize_regex"
+    )]
     pub(crate) external_path: Option<Regex>,
 }
 
@@ -166,18 +195,22 @@ impl LocalMappingEntry {
 #[derive(Debug, Clone, PartialEq)]
 pub struct AuthorityReplacement {
     pub authority: Authority,
-    pub path: Option<String>
+    pub path: Option<String>,
 }
 
 impl From<Authority> for AuthorityReplacement {
     fn from(authority: Authority) -> Self {
-        Self { authority, path: None }
+        Self {
+            authority,
+            path: None,
+        }
     }
 }
 
 impl<'de> Deserialize<'de> for AuthorityReplacement {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where D: serde::Deserializer<'de>
+    where
+        D: serde::Deserializer<'de>,
     {
         let string = String::deserialize(deserializer)?;
         match string.split_once('/') {
@@ -188,7 +221,7 @@ impl<'de> Deserialize<'de> for AuthorityReplacement {
             None => Ok(Self {
                 authority: string.parse().map_err(serde::de::Error::custom)?,
                 path: None,
-            })
+            }),
         }
     }
 }
@@ -208,31 +241,51 @@ pub(crate) struct Config {
     pub(crate) no_auth: bool,
 }
 
-fn load_local_targets(broker_id: &str, local_target_path: &Option<PathBuf>) -> Result<LocalMapping> {
+fn load_local_targets(
+    broker_id: &str,
+    local_target_path: &Option<PathBuf>,
+) -> Result<LocalMapping> {
     if let Some(json_file) = local_target_path {
         if json_file.exists() {
             let json_string = std::fs::read_to_string(json_file)?;
-            return Ok(LocalMapping{entries:serde_json::from_str(&json_string)?});
+            return Ok(LocalMapping {
+                entries: serde_json::from_str(&json_string)?,
+            });
         }
     }
     Ok(example_targets::example_local(broker_id))
 }
 
-async fn load_public_targets(client: &Client, url: &PathOrUri) -> Result<CentralMapping, BeamConnectError> {
+async fn load_public_targets(
+    client: &Client,
+    url: &PathOrUri,
+) -> Result<CentralMapping, BeamConnectError> {
     match url {
-        PathOrUri::Path(path) => {
-            serde_json::from_slice(&std::fs::read(path).map_err(|e| BeamConnectError::ConfigurationError(format!("Failed to open central config file: {e}")))?)
-        },
-        PathOrUri::Uri(url) => {
-            Ok(client.get(url.to_string())
-                .send().await
-                .map_err(|e| BeamConnectError::ConfigurationError(format!("Cannot retrieve central service discovery configuration: {e}")))?
-                .json()
-                .await
-                .map_err(|e| BeamConnectError::ConfigurationError(format!("Invalid central site discovery response: {e}")))?
-            )
-        },
-    }.map_err(|e| BeamConnectError::ConfigurationError(format!("Cannot parse central service discovery configuration: {e}")))
+        PathOrUri::Path(path) => serde_json::from_slice(&std::fs::read(path).map_err(|e| {
+            BeamConnectError::ConfigurationError(format!("Failed to open central config file: {e}"))
+        })?),
+        PathOrUri::Uri(url) => Ok(client
+            .get(url.to_string())
+            .send()
+            .await
+            .map_err(|e| {
+                BeamConnectError::ConfigurationError(format!(
+                    "Cannot retrieve central service discovery configuration: {e}"
+                ))
+            })?
+            .json()
+            .await
+            .map_err(|e| {
+                BeamConnectError::ConfigurationError(format!(
+                    "Invalid central site discovery response: {e}"
+                ))
+            })?),
+    }
+    .map_err(|e| {
+        BeamConnectError::ConfigurationError(format!(
+            "Cannot parse central service discovery configuration: {e}"
+        ))
+    })
 }
 
 fn build_client(tls_cert_dir: Option<&PathBuf>) -> Result<Client> {
@@ -248,7 +301,7 @@ fn build_client(tls_cert_dir: Option<&PathBuf>) -> Result<Client> {
                     Err(e) => {
                         warn!("Failed to read cert at {path_buf:?}: {e}");
                         continue;
-                    },
+                    }
                 };
                 client_builder = client_builder.add_root_certificate(cert);
             }
@@ -260,13 +313,12 @@ fn build_client(tls_cert_dir: Option<&PathBuf>) -> Result<Client> {
 impl Config {
     pub(crate) async fn load() -> Result<Self> {
         let args = CliArgs::parse();
-        let broker_id = args.app_id
-            .splitn(3, '.')
-            .last()
-            .ok_or_else(|| BeamConnectError::ConfigurationError(format!("Invalid beam id: {}", args.app_id)))?;
+        let broker_id = args.app_id.splitn(3, '.').last().ok_or_else(|| {
+            BeamConnectError::ConfigurationError(format!("Invalid beam id: {}", args.app_id))
+        })?;
         set_broker_id(broker_id.to_owned());
         let app_id = AppId::new(&args.app_id)?;
-    
+
         let expire = args.expire;
         let client = build_client(args.tls_ca_certificates_dir.as_ref())?;
 
@@ -276,10 +328,12 @@ impl Config {
         let identity = Identity::from_pkcs8(
             read_to_string(args.ssl_cert_pem)?.as_bytes(),
             read_to_string(args.ssl_cert_key)?.as_bytes(),
-        ).expect("Failed to initialize identity for tls acceptor");
-        let tls_acceptor = Arc::new(native_tls::TlsAcceptor::new(identity)
-            .expect("Failed to initialize tls acceptor")
-            .into()
+        )
+        .expect("Failed to initialize identity for tls acceptor");
+        let tls_acceptor = Arc::new(
+            native_tls::TlsAcceptor::new(identity)
+                .expect("Failed to initialize tls acceptor")
+                .into(),
         );
 
         Ok(Config {
@@ -292,15 +346,15 @@ impl Config {
             targets_public,
             expire,
             client,
-            tls_acceptor
+            tls_acceptor,
         })
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use beam_lib::set_broker_id;
     use beam_lib::AppId;
+    use beam_lib::set_broker_id;
 
     use super::CentralMapping;
     use super::LocalMapping;
@@ -343,16 +397,22 @@ mod tests {
 
         let site = routes.next().unwrap();
         assert_eq!(site.virtualhost.to_string(), "ukt.virtual");
-        assert_eq!(site.beamconnect.to_string(), "connect.ukt-proxy.broker.ccp-it.dktk.dkfz.de");
+        assert_eq!(
+            site.beamconnect.to_string(),
+            "connect.ukt-proxy.broker.ccp-it.dktk.dkfz.de"
+        );
 
         let site = routes.next().unwrap();
         assert_eq!(site.virtualhost, "ukfr.virtual");
-        assert_eq!(site.beamconnect.to_string(), "connect.ukfr-proxy.broker.ccp-it.dktk.dkfz.de");
+        assert_eq!(
+            site.beamconnect.to_string(),
+            "connect.ukfr-proxy.broker.ccp-it.dktk.dkfz.de"
+        );
     }
 
     #[test]
     fn local_target_configuration() {
-        let broker_id = "broker.ccp-it.dktk.dkfz.de"; 
+        let broker_id = "broker.ccp-it.dktk.dkfz.de";
         set_broker_id(broker_id.to_owned());
         let serialized = r#"[
             {"external": "ifconfig.me","internal":"ifconfig.me/asdf","allowed":["connect1.proxy23.broker.ccp-it.dktk.dkfz.de","connect2.proxy23.broker.ccp-it.dktk.dkfz.de"]},
@@ -360,15 +420,23 @@ mod tests {
             {"external": "wttr.in","internal":"wttr.in","allowed":["connect1.proxy23.broker.ccp-it.dktk.dkfz.de","connect2.proxy23.broker.ccp-it.dktk.dkfz.de"]},
             {"external": "node23.uk12.network","internal":"host23.internal.network","allowed":["proxy23.broker.ccp-it.dktk.dkfz.de"]}
         ]"#;
-        let obj: LocalMapping = LocalMapping{entries:serde_json::from_str(serialized).unwrap()};
+        let obj: LocalMapping = LocalMapping {
+            entries: serde_json::from_str(serialized).unwrap(),
+        };
         let expect = example_local(&broker_id);
         assert_eq!(obj.entries.len(), expect.entries.len());
-        assert!(obj.get(&hyper::Uri::from_static("http://node23.uk12.network")).unwrap().can_be_accessed_by(&AppId::new("foobar.proxy23.broker.ccp-it.dktk.dkfz.de").unwrap()));
+        assert!(
+            obj.get(&hyper::Uri::from_static("http://node23.uk12.network"))
+                .unwrap()
+                .can_be_accessed_by(
+                    &AppId::new("foobar.proxy23.broker.ccp-it.dktk.dkfz.de").unwrap()
+                )
+        );
 
-        for (entry,ref_entry) in obj.entries.iter().zip(expect.entries.iter()) {
-            assert_eq!(entry.needle,ref_entry.needle);
-            assert_eq!(entry.replace,ref_entry.replace);
-            assert_eq!(entry.allowed,ref_entry.allowed);
+        for (entry, ref_entry) in obj.entries.iter().zip(expect.entries.iter()) {
+            assert_eq!(entry.needle, ref_entry.needle);
+            assert_eq!(entry.replace, ref_entry.replace);
+            assert_eq!(entry.allowed, ref_entry.allowed);
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -77,13 +77,13 @@ struct CliArgs {
     #[clap(long, env, value_parser)]
     tls_ca_certificates_dir: Option<PathBuf>,
 
-    /// Pem file used for ssl support. Will use a snakeoil pem if unset.
+    /// Pem file used for tls termination (e.g. the server certificate).
     #[clap(long, env, value_parser)]
-    ssl_cert_pem: Option<String>,
+    tls_termination_cert_path: Option<String>,
 
-    /// Key file used for ssl support. Will use a snakeoil key if unset.
+    /// Key file used for tls termination (e.g. the server key).
     #[clap(long, env, value_parser)]
-    ssl_cert_key: Option<String>,
+    tls_termination_key_path: Option<String>,
 
     /// Expiry time of the request in seconds
     #[clap(long, env, value_parser, default_value = "3600")]
@@ -337,8 +337,10 @@ impl Config {
 
         let targets_public = load_public_targets(&client, &args.discovery_url).await?;
         let targets_local = load_local_targets(&broker_id, &args.local_targets_file)?;
-        let tls_acceptor =
-            build_tls_config(args.ssl_cert_pem.as_ref(), args.ssl_cert_key.as_ref())?;
+        let tls_acceptor = build_tls_config(
+            args.tls_termination_cert_path.as_ref(),
+            args.tls_termination_key_path.as_ref(),
+        )?;
 
         Ok(Config {
             proxy_url: args.proxy_url,

--- a/src/config.rs
+++ b/src/config.rs
@@ -78,22 +78,12 @@ struct CliArgs {
     tls_ca_certificates_dir: Option<PathBuf>,
 
     /// Pem file used for ssl support. Will use a snakeoil pem if unset.
-    #[clap(
-        long,
-        env,
-        value_parser,
-        default_value = "/etc/ssl/certs/ssl-cert-snakeoil.pem"
-    )]
-    ssl_cert_pem: PathBuf,
+    #[clap(long, env, value_parser)]
+    ssl_cert_pem: Option<String>,
 
     /// Key file used for ssl support. Will use a snakeoil key if unset.
-    #[clap(
-        long,
-        env,
-        value_parser,
-        default_value = "/etc/ssl/private/ssl-cert-snakeoil.key"
-    )]
-    ssl_cert_key: PathBuf,
+    #[clap(long, env, value_parser)]
+    ssl_cert_key: Option<String>,
 
     /// Expiry time of the request in seconds
     #[clap(long, env, value_parser, default_value = "3600")]
@@ -237,7 +227,7 @@ pub(crate) struct Config {
     pub(crate) targets_public: CentralMapping,
     pub(crate) expire: u64,
     pub(crate) client: Client,
-    pub(crate) tls_acceptor: Arc<TlsAcceptor>,
+    pub(crate) tls_acceptor: Option<Arc<TlsAcceptor>>,
     pub(crate) no_auth: bool,
 }
 
@@ -288,6 +278,29 @@ async fn load_public_targets(
     })
 }
 
+fn build_tls_config(
+    ssl_cert_pem: Option<&String>,
+    ssl_cert_key: Option<&String>,
+) -> Result<Option<Arc<TlsAcceptor>>> {
+    match (
+        ssl_cert_pem.filter(|p| !p.is_empty()),
+        ssl_cert_key.filter(|k| !k.is_empty()),
+    ) {
+        (Some(pem), Some(key)) => {
+            let identity = Identity::from_pkcs8(
+                read_to_string(pem)?.as_bytes(),
+                read_to_string(key)?.as_bytes(),
+            )?;
+            let tls_acceptor = Arc::new(native_tls::TlsAcceptor::new(identity)?.into());
+            Ok(Some(tls_acceptor))
+        }
+        (Some(_), None) | (None, Some(_)) => {
+            anyhow::bail!("SSL certificate PEM and key must both be provided")
+        }
+        _ => Ok(None),
+    }
+}
+
 fn build_client(tls_cert_dir: Option<&PathBuf>) -> Result<Client> {
     let mut client_builder = Client::builder();
     if let Some(tls_ca_dir) = tls_cert_dir {
@@ -324,17 +337,8 @@ impl Config {
 
         let targets_public = load_public_targets(&client, &args.discovery_url).await?;
         let targets_local = load_local_targets(&broker_id, &args.local_targets_file)?;
-
-        let identity = Identity::from_pkcs8(
-            read_to_string(args.ssl_cert_pem)?.as_bytes(),
-            read_to_string(args.ssl_cert_key)?.as_bytes(),
-        )
-        .expect("Failed to initialize identity for tls acceptor");
-        let tls_acceptor = Arc::new(
-            native_tls::TlsAcceptor::new(identity)
-                .expect("Failed to initialize tls acceptor")
-                .into(),
-        );
+        let tls_acceptor =
+            build_tls_config(args.ssl_cert_pem.as_ref(), args.ssl_cert_key.as_ref())?;
 
         Ok(Config {
             proxy_url: args.proxy_url,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,10 +1,10 @@
 use std::string::FromUtf8Error;
 
-use hyper::Uri;
 use beam_lib::AppOrProxyId;
+use hyper::Uri;
 use thiserror::Error;
 
-#[derive(Error,Debug)]
+#[derive(Error, Debug)]
 pub(crate) enum BeamConnectError {
     #[error("Regular proxy timeout")]
     ProxyTimeoutError,
@@ -31,8 +31,6 @@ pub(crate) enum BeamConnectError {
     #[error("Reply invalid: {0}")]
     ReplyInvalid(String),
     #[error("Configuration error: {0}")]
-    ConfigurationError(String)
-    // #[error("Unable to build reply: {0}")]
-    // BuildReplyFailed(hyper::http::Error)
+    ConfigurationError(String), // #[error("Unable to build reply: {0}")]
+                                // BuildReplyFailed(hyper::http::Error)
 }
-

--- a/src/example_targets.rs
+++ b/src/example_targets.rs
@@ -1,26 +1,41 @@
-use hyper::http::uri::Authority;
 use beam_lib::{AppId, AppOrProxyId, ProxyId};
+use hyper::http::uri::Authority;
 
 use crate::config::{LocalMapping, LocalMappingEntry};
 
 pub(crate) fn example_local(broker_id: &str) -> LocalMapping {
     let proxy23 = ProxyId::new(&format!("proxy23.{}", broker_id)).unwrap();
-    let app1_id: AppOrProxyId = AppId::new(&format!("connect1.{}",proxy23)).unwrap().into();
-    let app2_id: AppOrProxyId = AppId::new(&format!("connect2.{}",proxy23)).unwrap().into();
-    let map = LocalMapping {entries: [
-        ("ifconfig.me", "ifconfig.me/asdf", vec![app1_id.clone(), app2_id.clone()]),
-        ("ip-api.com", "ip-api.com", vec![app1_id.clone(), app2_id.clone()]),
-        ("wttr.in", "wttr.in", vec![app1_id.clone(), app2_id.clone()]),
-        ("node23.uk12.network", "host23.internal.network", vec![proxy23.into()])
-    ].map(|(needle,replace,allowed)| LocalMappingEntry {
-        needle: Authority::from_static(needle),
-        replace: serde_json::from_value(serde_json::Value::String(replace.to_owned())).unwrap(),
-        allowed,
-        force_https: false,
-        reset_host: false,
-        external_path: None,
-    })
-    .into_iter()
-    .collect()};
+    let app1_id: AppOrProxyId = AppId::new(&format!("connect1.{}", proxy23)).unwrap().into();
+    let app2_id: AppOrProxyId = AppId::new(&format!("connect2.{}", proxy23)).unwrap().into();
+    let map = LocalMapping {
+        entries: [
+            (
+                "ifconfig.me",
+                "ifconfig.me/asdf",
+                vec![app1_id.clone(), app2_id.clone()],
+            ),
+            (
+                "ip-api.com",
+                "ip-api.com",
+                vec![app1_id.clone(), app2_id.clone()],
+            ),
+            ("wttr.in", "wttr.in", vec![app1_id.clone(), app2_id.clone()]),
+            (
+                "node23.uk12.network",
+                "host23.internal.network",
+                vec![proxy23.into()],
+            ),
+        ]
+        .map(|(needle, replace, allowed)| LocalMappingEntry {
+            needle: Authority::from_static(needle),
+            replace: serde_json::from_value(serde_json::Value::String(replace.to_owned())).unwrap(),
+            allowed,
+            force_https: false,
+            reset_host: false,
+            external_path: None,
+        })
+        .into_iter()
+        .collect(),
+    };
     map
 }

--- a/src/logic_ask.rs
+++ b/src/logic_ask.rs
@@ -1,64 +1,78 @@
-use std::str::FromStr;
+use beam_lib::{AppId, FailureStrategy, MsgId, TaskRequest, TaskResult, WorkStatus};
 use http_body_util::combinators::BoxBody;
 use http_body_util::{BodyExt, Full};
 use hyper::body::{Bytes, Incoming};
 use hyper::http::HeaderValue;
 use hyper::http::uri::{Authority, Scheme};
-use hyper::{Request, header, StatusCode, Uri};
-use tracing::{debug, error, info, info_span, trace, warn, Instrument};
+use hyper::{Request, StatusCode, Uri, header};
 use serde_json::Value;
-use beam_lib::{AppId, TaskResult, TaskRequest, WorkStatus, FailureStrategy, MsgId};
+use std::str::FromStr;
+use tracing::{Instrument, debug, error, info, info_span, trace, warn};
 
-use crate::config::CentralMapping;
 use crate::Response;
-use crate::{config::Config, structs::MyStatusCode, msg::{HttpRequest, HttpResponse}};
+use crate::config::CentralMapping;
+use crate::{
+    config::Config,
+    msg::{HttpRequest, HttpResponse},
+    structs::MyStatusCode,
+};
 
 /// GET   http://some.internal.system?a=b&c=d
 /// Host: <identical>
-/// This function knows from its map which app to direct the message to 
+/// This function knows from its map which app to direct the message to
 pub(crate) async fn handler_http(
     mut req: Request<Incoming>,
     config: &Config,
     https_authority: Option<Authority>,
 ) -> Result<Response, MyStatusCode> {
-
     let targets = &config.targets_public;
     let method = req.method().to_owned();
     let uri = req.uri().to_owned();
 
-    let host_header_auth = req.headers()
+    let host_header_auth = req
+        .headers()
         .get(header::HOST)
         .and_then(|v| v.to_str().ok())
         .and_then(|v| Authority::from_str(v).ok());
-    let host_replace_header_auth = req.headers()
+    let host_replace_header_auth = req
+        .headers()
         .get("x-replace-host")
         .and_then(|v| v.to_str().ok())
         .and_then(|v| Authority::from_str(v).ok());
-    let authority = https_authority
-        .as_ref()
-        .or(uri.authority());
+    let authority = https_authority.as_ref().or(uri.authority());
 
     if authority.is_none() && uri.path() == "/sites" {
-            // Case 1 for sites request: no authority set and /sites
-            return respond_with_sites(targets)
+        // Case 1 for sites request: no authority set and /sites
+        return respond_with_sites(targets);
     }
 
-    let authority = host_replace_header_auth.as_ref()
+    let authority = host_replace_header_auth
+        .as_ref()
         .or(authority)
         .or(host_header_auth.as_ref());
     let Some(authority) = authority else {
-            return Err(StatusCode::BAD_REQUEST.into())
+        return Err(StatusCode::BAD_REQUEST.into());
     };
     let headers = req.headers_mut();
 
-    headers.insert(header::VIA, format!("Via: Samply.Beam.Connect/0.1 {}", config.my_app_id).parse().unwrap());
+    headers.insert(
+        header::VIA,
+        format!("Via: Samply.Beam.Connect/0.1 {}", config.my_app_id)
+            .parse()
+            .unwrap(),
+    );
 
     let auth = if config.no_auth {
+        headers.remove(header::PROXY_AUTHORIZATION).unwrap_or(
+            config
+                .proxy_auth
+                .parse()
+                .expect("Proxy auth header could not be generated."),
+        )
+    } else {
         headers
             .remove(header::PROXY_AUTHORIZATION)
-            .unwrap_or(config.proxy_auth.parse().expect("Proxy auth header could not be generated."))
-    } else {
-        headers.remove(header::PROXY_AUTHORIZATION).ok_or(StatusCode::PROXY_AUTHENTICATION_REQUIRED)?
+            .ok_or(StatusCode::PROXY_AUTHENTICATION_REQUIRED)?
     };
 
     // Re-pack Authorization: Not necessary since we're not looking at the Authorization header.
@@ -66,18 +80,18 @@ pub(crate) async fn handler_http(
     //     return Err(StatusCode::CONFLICT.into());
     // }
 
-    let Some(target) = &targets
-        .get(authority)
-        .map(|target| &target.beamconnect) else {
-            return if uri.path() == "/sites" {
-                // Case 2: target not in sites and /sites
-                respond_with_sites(targets)
-            } else {
-                warn!("Failed to lookup virtualhost in central mapping: {}", authority);
-                Err(StatusCode::UNAUTHORIZED.into())
-            }
+    let Some(target) = &targets.get(authority).map(|target| &target.beamconnect) else {
+        return if uri.path() == "/sites" {
+            // Case 2: target not in sites and /sites
+            respond_with_sites(targets)
+        } else {
+            warn!(
+                "Failed to lookup virtualhost in central mapping: {}",
+                authority
+            );
+            Err(StatusCode::UNAUTHORIZED.into())
         };
-
+    };
 
     // Set the right authority as it might have been passed by the caller because it was a CONNECT request
     *req.uri_mut() = {
@@ -96,17 +110,28 @@ pub(crate) async fn handler_http(
     info!("{method} {} via {target}", req.uri());
     let span = info_span!("request", %method, via = %target, url = %req.uri());
     #[cfg(feature = "sockets")]
-    return crate::sockets::handle_via_sockets(req, config, target, auth).instrument(span).await;
+    return crate::sockets::handle_via_sockets(req, config, target, auth)
+        .instrument(span)
+        .await;
     #[cfg(not(feature = "sockets"))]
-    return handle_via_tasks(req, &config, target, auth).instrument(span).await;
+    return handle_via_tasks(req, &config, target, auth)
+        .instrument(span)
+        .await;
 }
 
-async fn handle_via_tasks(req: Request<Incoming>, config: &Config, target: &AppId, auth: HeaderValue) -> Result<Response, MyStatusCode> {
+async fn handle_via_tasks(
+    req: Request<Incoming>,
+    config: &Config,
+    target: &AppId,
+    auth: HeaderValue,
+) -> Result<Response, MyStatusCode> {
     let msg = http_req_to_struct(req, &config.my_app_id, &target, config.expire).await?;
 
     // Send to Proxy
     debug!("SENDING request to Proxy: {msg:#?}");
-    let resp = config.client.post(format!("{}v1/tasks", config.proxy_url))
+    let resp = config
+        .client
+        .post(format!("{}v1/tasks", config.proxy_url))
         .header(header::AUTHORIZATION, auth.clone())
         .json(&msg)
         .send()
@@ -119,8 +144,12 @@ async fn handle_via_tasks(req: Request<Incoming>, config: &Config, target: &AppI
     let mut tries = 0_u8;
     const MAX_RETRIES: u8 = 3;
     let resp = loop {
-        let resp = config.client
-            .get(format!("{}v1/tasks/{}/results?wait_count=1", config.proxy_url, msg.id))
+        let resp = config
+            .client
+            .get(format!(
+                "{}v1/tasks/{}/results?wait_count=1",
+                config.proxy_url, msg.id
+            ))
             .header(header::AUTHORIZATION, auth.clone())
             .header(header::ACCEPT, "application/json")
             .send()
@@ -136,7 +165,7 @@ async fn handle_via_tasks(req: Request<Incoming>, config: &Config, target: &AppI
             s if tries > MAX_RETRIES => {
                 warn!("Error fetching reply, got code: {s}. Giving up");
                 return Err(StatusCode::BAD_GATEWAY)?;
-            },
+            }
             s => {
                 warn!("Failed to fetch reply, status: {s}. Retrying");
                 tries += 1;
@@ -145,60 +174,75 @@ async fn handle_via_tasks(req: Request<Incoming>, config: &Config, target: &AppI
         tries += 1;
     };
 
-    let mut task_results = resp.json::<Vec<TaskResult<beam_lib::RawString>>>().await
+    let mut task_results = resp
+        .json::<Vec<TaskResult<beam_lib::RawString>>>()
+        .await
         .map_err(|e| {
             warn!("Unable to parse beam results: {e}");
             StatusCode::INTERNAL_SERVER_ERROR
         })?;
     let Some(result) = task_results.pop() else {
-        error!("Reply had more than one answer (namely: {}). This should not happen; discarding request.", task_results.len());
+        error!(
+            "Reply had more than one answer (namely: {}). This should not happen; discarding request.",
+            task_results.len()
+        );
         return Err(StatusCode::INTERNAL_SERVER_ERROR.into());
     };
-    debug!("Got reply with status {:?}: {:#?}", result.status, result.body);
+    debug!(
+        "Got reply with status {:?}: {:#?}",
+        result.status, result.body
+    );
     let response_inner: HttpResponse = match result.status {
-        WorkStatus::Succeeded => {
-            serde_json::from_str(&result.body.0)
-                .map_err(|e| {
-                    warn!("Unable to parse HTTP response: {e}");
-                    StatusCode::BAD_GATEWAY
-                })?
-        },
+        WorkStatus::Succeeded => serde_json::from_str(&result.body.0).map_err(|e| {
+            warn!("Unable to parse HTTP response: {e}");
+            StatusCode::BAD_GATEWAY
+        })?,
         e => {
-            warn!("Reply had unexpected workresult code: {e:?}: {:#?}", result.body);
+            warn!(
+                "Reply had unexpected workresult code: {e:?}: {:#?}",
+                result.body
+            );
             return Err(StatusCode::BAD_GATEWAY)?;
         }
     };
 
     if let Some(expected_len) = response_inner.headers.get(header::CONTENT_LENGTH) {
-        let expected_len = usize::from_str(expected_len.to_str()?)
-            .map_err(|e| {
-                error!("We got an invalid content length: {e}. This is probably a bug.");
-                StatusCode::INTERNAL_SERVER_ERROR
-            })?;
+        let expected_len = usize::from_str(expected_len.to_str()?).map_err(|e| {
+            error!("We got an invalid content length: {e}. This is probably a bug.");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
         if expected_len != response_inner.body.len() {
-            error!("Critical Error: The other Proxy received a reply with length {expected_len}; now it's {}.", response_inner.body.len());
+            error!(
+                "Critical Error: The other Proxy received a reply with length {expected_len}; now it's {}.",
+                response_inner.body.len()
+            );
             return Err(StatusCode::INTERNAL_SERVER_ERROR)?;
         }
     }
 
-    let mut resp = Response::builder()
-        .status(response_inner.status);
+    let mut resp = Response::builder().status(response_inner.status);
     *resp.headers_mut().unwrap() = response_inner.headers;
     let resp = resp
-        .body(BoxBody::new(Full::new(Bytes::from(response_inner.body)).map_err(Into::into)))
+        .body(BoxBody::new(
+            Full::new(Bytes::from(response_inner.body)).map_err(Into::into),
+        ))
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
     Ok(resp)
 }
 
-async fn http_req_to_struct(mut req: Request<Incoming>, my_id: &AppId, target_id: &AppId, expire: u64) -> Result<TaskRequest<HttpRequest>, MyStatusCode> {
+async fn http_req_to_struct(
+    mut req: Request<Incoming>,
+    my_id: &AppId,
+    target_id: &AppId,
+    expire: u64,
+) -> Result<TaskRequest<HttpRequest>, MyStatusCode> {
     let method = req.method().clone();
     let url = req.uri().clone();
     let headers = req.headers().clone();
-    let body = req.body_mut().collect().await
-        .map_err(|e| {
-            warn!("Failed to read body: {e}");
-            StatusCode::BAD_REQUEST
+    let body = req.body_mut().collect().await.map_err(|e| {
+        warn!("Failed to read body: {e}");
+        StatusCode::BAD_REQUEST
     })?;
 
     let http_req = HttpRequest {
@@ -214,9 +258,9 @@ async fn http_req_to_struct(mut req: Request<Incoming>, my_id: &AppId, target_id
         failure_strategy: FailureStrategy::Discard,
         metadata: Value::Null,
         ttl: format!("{expire}s"),
-        id: MsgId::new()
+        id: MsgId::new(),
     };
-    
+
     Ok(msg)
 }
 

--- a/src/logic_ask.rs
+++ b/src/logic_ask.rs
@@ -97,10 +97,14 @@ pub(crate) async fn handler_http(
     *req.uri_mut() = {
         let mut parts = req.uri().to_owned().into_parts();
         parts.authority = Some(authority.clone());
-        if https_authority.is_some() {
-            parts.scheme = Some(Scheme::HTTPS);
-        } else {
-            parts.scheme = Some(Scheme::HTTP);
+        // CONNECT requests don't have a scheme
+        if req.method() != hyper::Method::CONNECT {
+            // If this is set it means we came from a tls terminated request which means the client executing the request should use https
+            if https_authority.is_some() {
+                parts.scheme = Some(Scheme::HTTPS);
+            } else {
+                parts.scheme = Some(Scheme::HTTP);
+            }
         }
         Uri::from_parts(parts).map_err(|e| {
             warn!("Could not transform uri authority: {e}");
@@ -125,6 +129,10 @@ async fn handle_via_tasks(
     target: &AppId,
     auth: HeaderValue,
 ) -> Result<Response, MyStatusCode> {
+    if req.method() == hyper::Method::CONNECT {
+        warn!("Forwarding of CONNECT requests is only supported with the 'sockets' feature");
+        return Err(StatusCode::NOT_IMPLEMENTED.into());
+    }
     let msg = http_req_to_struct(req, &config.my_app_id, &target, config.expire).await?;
 
     // Send to Proxy

--- a/src/logic_reply.rs
+++ b/src/logic_reply.rs
@@ -2,12 +2,16 @@ use std::{pin::pin, sync::Arc, time::Duration};
 
 use beam_lib::{AppOrProxyId, TaskRequest, TaskResult, WorkStatus};
 use futures_util::future::TryJoinAll;
-use hyper::{header, StatusCode, Uri, Method, http::uri::PathAndQuery};
-use tracing::{debug, field, info, trace, warn, Instrument, Span};
-use serde_json::Value;
+use hyper::{Method, StatusCode, Uri, header, http::uri::PathAndQuery};
 use reqwest::Response;
+use serde_json::Value;
+use tracing::{Instrument, Span, debug, field, info, trace, warn};
 
-use crate::{config::Config, errors::BeamConnectError, msg::{HttpResponse, HttpRequest}};
+use crate::{
+    config::Config,
+    errors::BeamConnectError,
+    msg::{HttpRequest, HttpResponse},
+};
 
 pub(crate) async fn process_requests(config: &'static Config) -> Result<(), BeamConnectError> {
     // Fetch a batch of tasks and executed them in parallel
@@ -21,16 +25,17 @@ pub(crate) async fn process_requests(config: &'static Config) -> Result<(), Beam
 }
 
 #[tracing::instrument(skip_all, fields(from = %task.from.hide_broker(), method = %task.body.method, orig_url = %task.body.url, dst_url))]
-async fn claim_or_answer(task: TaskRequest<HttpRequest>, config: &'static Config) -> Result<(), BeamConnectError> {
+async fn claim_or_answer(
+    task: TaskRequest<HttpRequest>,
+    config: &'static Config,
+) -> Result<(), BeamConnectError> {
     let task = Arc::new(task);
     let task2 = Arc::clone(&task);
-    let mut execute_task = Box::pin(async move {
-        execute_http_task(&task2, &config).await
-    });
+    let mut execute_task = Box::pin(async move { execute_http_task(&task2, &config).await });
     let mut claim_task = pin!(claim_task(&task, &config));
     tokio::select! {
         claimed = &mut claim_task => {
-           claimed?; 
+           claimed?;
            let task = Arc::clone(&task);
            tokio::spawn(async move {
                 if let Err(e) = send_reply(&task, &config, execute_task.await).await {
@@ -55,8 +60,14 @@ async fn claim_task<T>(task: &TaskRequest<T>, config: &Config) -> Result<(), Bea
         body: (),
     };
     debug!("Claiming: {msg:?}");
-    let resp = config.client
-        .put(format!("{}v1/tasks/{}/results/{}", config.proxy_url, task.id, config.my_app_id.clone()))
+    let resp = config
+        .client
+        .put(format!(
+            "{}v1/tasks/{}/results/{}",
+            config.proxy_url,
+            task.id,
+            config.my_app_id.clone()
+        ))
         .header(header::AUTHORIZATION, config.proxy_auth.clone())
         .json(&msg)
         .send()
@@ -66,35 +77,53 @@ async fn claim_task<T>(task: &TaskRequest<T>, config: &Config) -> Result<(), Bea
     if let StatusCode::CREATED | StatusCode::NO_CONTENT = resp.status() {
         Ok(())
     } else {
-        Err(BeamConnectError::ProxyOtherError(format!("Got error code {} trying to submit our result.", resp.status())))
+        Err(BeamConnectError::ProxyOtherError(format!(
+            "Got error code {} trying to submit our result.",
+            resp.status()
+        )))
     }
 }
 
-async fn send_reply(task: &TaskRequest<HttpRequest>, config: &Config, resp: Result<Response, BeamConnectError>) -> Result<(), BeamConnectError> {
+async fn send_reply(
+    task: &TaskRequest<HttpRequest>,
+    config: &Config,
+    resp: Result<Response, BeamConnectError>,
+) -> Result<(), BeamConnectError> {
     let (reply_body, status) = match resp {
         Ok(resp) => {
             let status = resp.status();
             let headers = resp.headers().clone();
             if !status.is_success() {
-                warn!("Httptask returned with status {}. Reporting failure to broker.", resp.status());
+                warn!(
+                    "Httptask returned with status {}. Reporting failure to broker.",
+                    resp.status()
+                );
                 // warn!("Response body was: {}", &body);
             };
-            let body = resp.bytes().await
+            let body = resp
+                .bytes()
+                .await
                 .map_err(BeamConnectError::FailedToReadTargetsReply)?;
-            (HttpResponse {
-                status,
-                headers,
-                body: body.to_vec()
-            }, WorkStatus::Succeeded)
-        },
+            (
+                HttpResponse {
+                    status,
+                    headers,
+                    body: body.to_vec(),
+                },
+                WorkStatus::Succeeded,
+            )
+        }
         Err(e) => {
             warn!("Failed to execute http task. Err: {e}");
-            (HttpResponse { 
-                body: b"Error executing http task. See beam connect logs".to_vec(),
-                status: StatusCode::INTERNAL_SERVER_ERROR,
-                headers: Default::default(), 
-            }, WorkStatus::PermFailed)
-        },
+            (
+                HttpResponse {
+                    body: b"Error executing http task. See beam connect logs".to_vec(),
+                    status: StatusCode::INTERNAL_SERVER_ERROR,
+                    headers: Default::default(),
+                },
+                WorkStatus::PermFailed,
+            )
+        }
     };
     let msg = TaskResult {
         from: config.my_app_id.clone().into(),
@@ -105,8 +134,14 @@ async fn send_reply(task: &TaskRequest<HttpRequest>, config: &Config, resp: Resu
         body: reply_body,
     };
     debug!("Delivering response to Proxy: {msg:?}");
-    let resp = config.client
-        .put(format!("{}v1/tasks/{}/results/{}", config.proxy_url, task.id, config.my_app_id.clone()))
+    let resp = config
+        .client
+        .put(format!(
+            "{}v1/tasks/{}/results/{}",
+            config.proxy_url,
+            task.id,
+            config.my_app_id.clone()
+        ))
         .header(header::AUTHORIZATION, config.proxy_auth.clone())
         .json(&msg)
         .send()
@@ -116,24 +151,35 @@ async fn send_reply(task: &TaskRequest<HttpRequest>, config: &Config, resp: Resu
     if let StatusCode::CREATED | StatusCode::NO_CONTENT = resp.status() {
         Ok(())
     } else {
-        Err(BeamConnectError::ProxyOtherError(format!("Got error code {} trying to submit our result.", resp.status())))
+        Err(BeamConnectError::ProxyOtherError(format!(
+            "Got error code {} trying to submit our result.",
+            resp.status()
+        )))
     }
 }
 
-async fn execute_http_task(task: &TaskRequest<HttpRequest>, config: &Config) -> Result<Response, BeamConnectError> {
+async fn execute_http_task(
+    task: &TaskRequest<HttpRequest>,
+    config: &Config,
+) -> Result<Response, BeamConnectError> {
     let task_req = &task.body;
     let target = config
         .targets_local
-        .get(&task_req.url) 
+        .get(&task_req.url)
         .ok_or_else(|| BeamConnectError::NoLocalMapping(task_req.url.clone()))?;
     match &task.from {
-        AppOrProxyId::App(app) if target.can_be_accessed_by(app) => {},
-        id => return Err(BeamConnectError::IdNotAuthorizedToAccessUrl(id.clone(), task_req.url.clone())),
+        AppOrProxyId::App(app) if target.can_be_accessed_by(app) => {}
+        id => {
+            return Err(BeamConnectError::IdNotAuthorizedToAccessUrl(
+                id.clone(),
+                task_req.url.clone(),
+            ));
+        }
     };
     if task_req.method == Method::CONNECT {
         debug!("Connect Request URL: {:?}", task_req.url);
     }
-    
+
     let mut uri = Uri::builder();
     // Normal non CONNECT http request replacement
     if let Some(scheme) = task_req.url.scheme_str() {
@@ -143,14 +189,24 @@ async fn execute_http_task(task: &TaskRequest<HttpRequest>, config: &Config) -> 
             uri = uri.scheme(scheme);
         }
         uri = if let Some(path) = target.replace.path {
-            uri.path_and_query(&format!("/{path}{}", task_req.url.path_and_query().unwrap_or(&PathAndQuery::from_static(""))))
+            uri.path_and_query(&format!(
+                "/{path}{}",
+                task_req
+                    .url
+                    .path_and_query()
+                    .unwrap_or(&PathAndQuery::from_static(""))
+            ))
         } else {
-            uri.path_and_query(task_req.url.path_and_query().unwrap_or(&PathAndQuery::from_static("")).as_str())
+            uri.path_and_query(
+                task_req
+                    .url
+                    .path_and_query()
+                    .unwrap_or(&PathAndQuery::from_static(""))
+                    .as_str(),
+            )
         };
-    } 
-    let uri = uri
-        .authority(target.replace.authority.to_owned())
-        .build()?;
+    }
+    let uri = uri.authority(target.replace.authority.to_owned()).build()?;
 
     Span::current().record("dst_url", field::display(&uri));
     let mut headers = task_req.headers.clone();
@@ -162,7 +218,8 @@ async fn execute_http_task(task: &TaskRequest<HttpRequest>, config: &Config) -> 
         headers.remove(header::HOST);
     }
     info!("Executing");
-    let resp = config.client
+    let resp = config
+        .client
         .request(task_req.method.clone(), uri.to_string())
         .headers(headers)
         .body(task_req.body.to_vec())
@@ -175,8 +232,12 @@ async fn execute_http_task(task: &TaskRequest<HttpRequest>, config: &Config) -> 
 async fn fetch_task(config: &Config) -> Result<Vec<TaskRequest<HttpRequest>>, BeamConnectError> {
     debug!("fetching requests from proxy");
     let probably_timeout = tokio::time::sleep(Duration::from_secs(20));
-    let resp = config.client
-        .get(format!("{}v1/tasks?to={}&wait_count=1&filter=todo", config.proxy_url, config.my_app_id))
+    let resp = config
+        .client
+        .get(format!(
+            "{}v1/tasks?to={}&wait_count=1&filter=todo",
+            config.proxy_url, config.my_app_id
+        ))
         .header(header::AUTHORIZATION, config.proxy_auth.clone())
         .header(header::ACCEPT, "application/json")
         .send()
@@ -185,19 +246,25 @@ async fn fetch_task(config: &Config) -> Result<Vec<TaskRequest<HttpRequest>>, Be
     match resp.status() {
         StatusCode::OK | StatusCode::PARTIAL_CONTENT => {
             trace!("Got tasks from beam: {resp:#?}");
-        },
+        }
         StatusCode::GATEWAY_TIMEOUT => return Err(BeamConnectError::ProxyTimeoutError),
         StatusCode::UNAUTHORIZED => return Err(BeamConnectError::ProxyRejectedAuthorization),
         s if probably_timeout.is_elapsed() => {
             debug!("Request to proxy timed out with StatusCode {s}");
-            return Err(BeamConnectError::ProxyTimeoutError)
-        },
+            return Err(BeamConnectError::ProxyTimeoutError);
+        }
         _ => {
-            return Err(BeamConnectError::ProxyOtherError(format!("Got response code {}", resp.status())));
+            return Err(BeamConnectError::ProxyOtherError(format!(
+                "Got response code {}",
+                resp.status()
+            )));
         }
     }
-    resp.json::<Vec<TaskRequest<HttpRequest>>>().await.map_err(|e| {
-        warn!("Unable to decode TaskRequest<HttpRequest>; error: {e}.");
-        BeamConnectError::ProxyOtherError(e.to_string())
-    }).map_err(Into::into)
+    resp.json::<Vec<TaskRequest<HttpRequest>>>()
+        .await
+        .map_err(|e| {
+            warn!("Unable to decode TaskRequest<HttpRequest>; error: {e}.");
+            BeamConnectError::ProxyOtherError(e.to_string())
+        })
+        .map_err(Into::into)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -160,19 +160,20 @@ pub(crate) async fn handler_http_wrapper(
     config: &'static Config,
 ) -> Result<Response, Infallible> {
     // On https connections we want to emulate that we successfully connected to get the actual http request
-    if req.method() == Method::CONNECT {
+    if req.method() == Method::CONNECT
+        && let Some(tls_acceptor) = &config.tls_acceptor
+    {
         tokio::spawn(async move {
             let authority = req.uri().authority().cloned();
             match hyper::upgrade::on(req).await {
                 Ok(connection) => {
-                    let tls_connection =
-                        match config.tls_acceptor.accept(TokioIo::new(connection)).await {
-                            Err(e) => {
-                                warn!("Error accepting tls connection: {e}");
-                                return;
-                            }
-                            Ok(s) => s,
-                        };
+                    let tls_connection = match tls_acceptor.accept(TokioIo::new(connection)).await {
+                        Ok(s) => s,
+                        Err(e) => {
+                            warn!("Error accepting tls connection: {e}");
+                            return;
+                        }
+                    };
                     server::conn::auto::Builder::new(TokioExecutor::new())
                         .serve_connection_with_upgrades(
                             TokioIo::new(tls_connection),

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,8 +2,15 @@ use std::{convert::Infallible, time::Duration};
 
 use config::Config;
 use http_body_util::combinators::BoxBody;
-use hyper::{body::{Bytes, Incoming}, service::service_fn, Method, Request};
-use hyper_util::{rt::{TokioExecutor, TokioIo}, server};
+use hyper::{
+    Method, Request,
+    body::{Bytes, Incoming},
+    service::service_fn,
+};
+use hyper_util::{
+    rt::{TokioExecutor, TokioIo},
+    server,
+};
 use logic_ask::handler_http;
 use tokio::{net::TcpListener, task::JoinHandle, time::Instant};
 use tracing::{debug, error, info, warn};
@@ -11,21 +18,29 @@ use tracing_subscriber::{EnvFilter, filter::LevelFilter};
 
 use crate::errors::BeamConnectError;
 
-mod shutdown;
-mod msg;
-mod example_targets;
+mod banner;
 mod config;
 mod errors;
-mod structs;
+mod example_targets;
 mod logic_ask;
 mod logic_reply;
-mod banner;
+mod msg;
+mod shutdown;
 #[cfg(feature = "sockets")]
 mod sockets;
+mod structs;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    tracing::subscriber::set_global_default(tracing_subscriber::fmt().with_env_filter(EnvFilter::builder().with_default_directive(LevelFilter::INFO.into()).from_env_lossy()).finish())?;
+    tracing::subscriber::set_global_default(
+        tracing_subscriber::fmt()
+            .with_env_filter(
+                EnvFilter::builder()
+                    .with_default_directive(LevelFilter::INFO.into())
+                    .from_env_lossy(),
+            )
+            .finish(),
+    )?;
     banner::print_banner();
     let config = Config::load().await?;
     let config: &'static _ = Box::leak(Box::new(config));
@@ -34,14 +49,13 @@ async fn main() -> anyhow::Result<()> {
     info!("Global site discovery: {:?}", config.targets_public);
     info!("Local site Access: {:?}", config.targets_local);
 
-
     let http_executor = tokio::task::spawn(async move {
         if config.targets_local.entries.is_empty() {
             info!("No local targets configured, will not poll for tasks.");
             return;
         };
         let mut tries = 0_u32;
-        let mut timer= std::pin::pin!(tokio::time::sleep(Duration::from_secs(60)));
+        let mut timer = std::pin::pin!(tokio::time::sleep(Duration::from_secs(60)));
         loop {
             debug!("Waiting for next request ...");
             if let Err(e) = logic_reply::process_requests(config).await {
@@ -49,12 +63,12 @@ async fn main() -> anyhow::Result<()> {
                     BeamConnectError::ProxyTimeoutError => (),
                     BeamConnectError::ProxyRejectedAuthorization => {
                         error!("Stopping task polling: {e}");
-                        break
+                        break;
                     }
                     _ if tries < 10 => {
                         tries += 1;
                         warn!("Error in processing request: {e}. Will continue with the next one.");
-                    },
+                    }
                     _ => {
                         warn!("Failed to process requests: {e}. Retrying in 30s.");
                         tokio::time::sleep(Duration::from_secs(30)).await;
@@ -63,7 +77,9 @@ async fn main() -> anyhow::Result<()> {
             }
             if timer.is_elapsed() {
                 tries = tries.saturating_sub(2);
-                timer.as_mut().reset(Instant::now() + Duration::from_secs(60));
+                timer
+                    .as_mut()
+                    .reset(Instant::now() + Duration::from_secs(60));
             }
         }
     });
@@ -149,23 +165,33 @@ pub(crate) async fn handler_http_wrapper(
             let authority = req.uri().authority().cloned();
             match hyper::upgrade::on(req).await {
                 Ok(connection) => {
-                    let tls_connection = match config.tls_acceptor.accept(TokioIo::new(connection)).await {
-                        Err(e) => {
-                            warn!("Error accepting tls connection: {e}");
-                            return;
-                        },
-                        Ok(s) => s,
-                    };
-                    server::conn::auto::Builder::new(TokioExecutor::new()).serve_connection_with_upgrades(TokioIo::new(tls_connection), service_fn(|req| {
-                        let authority = authority.clone();
-                        async move {
-                            match handler_http(req, config, authority).await {
-                                Ok(e) => Ok::<_, Infallible>(e),
-                                Err(e) => Ok(Response::builder().status(e.code).body(BoxBody::default()).unwrap()),
+                    let tls_connection =
+                        match config.tls_acceptor.accept(TokioIo::new(connection)).await {
+                            Err(e) => {
+                                warn!("Error accepting tls connection: {e}");
+                                return;
                             }
-                        }
-                    })).await.unwrap_or_else(|e| warn!("Failed to handle upgraded connection: {e}"));
-                },
+                            Ok(s) => s,
+                        };
+                    server::conn::auto::Builder::new(TokioExecutor::new())
+                        .serve_connection_with_upgrades(
+                            TokioIo::new(tls_connection),
+                            service_fn(|req| {
+                                let authority = authority.clone();
+                                async move {
+                                    match handler_http(req, config, authority).await {
+                                        Ok(e) => Ok::<_, Infallible>(e),
+                                        Err(e) => Ok(Response::builder()
+                                            .status(e.code)
+                                            .body(BoxBody::default())
+                                            .unwrap()),
+                                    }
+                                }
+                            }),
+                        )
+                        .await
+                        .unwrap_or_else(|e| warn!("Failed to handle upgraded connection: {e}"));
+                }
                 Err(e) => warn!("Failed to upgrade connection: {e}"),
             };
         });
@@ -173,8 +199,10 @@ pub(crate) async fn handler_http_wrapper(
     } else {
         match handler_http(req, config, None).await {
             Ok(e) => Ok(e),
-            Err(e) => Ok(Response::builder().status(e.code).body(BoxBody::default()).unwrap()),
+            Err(e) => Ok(Response::builder()
+                .status(e.code)
+                .body(BoxBody::default())
+                .unwrap()),
         }
     }
-
 }

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -1,7 +1,7 @@
-use hyper::{Method, Uri, HeaderMap, StatusCode};
-use serde::{Serialize, Deserialize};
+use hyper::{HeaderMap, Method, StatusCode, Uri};
+use serde::{Deserialize, Serialize};
 
-#[derive(Serialize,Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 pub(crate) struct HttpRequest {
     #[serde(with = "http_serde::method")]
     pub(crate) method: Method,
@@ -10,7 +10,7 @@ pub(crate) struct HttpRequest {
     #[serde(with = "http_serde::header_map")]
     pub(crate) headers: HeaderMap,
     #[serde(with = "serde_base64")]
-    pub(crate) body: Vec<u8>
+    pub(crate) body: Vec<u8>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -20,7 +20,7 @@ pub(crate) struct HttpResponse {
     #[serde(with = "http_serde::header_map")]
     pub(crate) headers: HeaderMap,
     #[serde(with = "serde_base64")]
-    pub(crate) body: Vec<u8>
+    pub(crate) body: Vec<u8>,
 }
 
 impl std::fmt::Debug for HttpResponse {
@@ -32,20 +32,21 @@ impl std::fmt::Debug for HttpResponse {
     }
 }
 
-
 // https://github.com/serde-rs/json/issues/360#issuecomment-330095360
 pub mod serde_base64 {
-    use serde::{Serializer, de, Deserialize, Deserializer};
     use openssl::base64;
+    use serde::{Deserialize, Deserializer, Serializer, de};
 
     pub fn serialize<S>(bytes: &[u8], serializer: S) -> Result<S::Ok, S::Error>
-        where S: Serializer
+    where
+        S: Serializer,
     {
         serializer.serialize_str(&base64::encode_block(bytes))
     }
 
     pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
-        where D: Deserializer<'de>
+    where
+        D: Deserializer<'de>,
     {
         base64::decode_block(<&str>::deserialize(deserializer)?).map_err(de::Error::custom)
     }

--- a/src/shutdown.rs
+++ b/src/shutdown.rs
@@ -2,7 +2,7 @@ use tracing::info;
 
 #[cfg(unix)]
 pub async fn wait_for_signal() {
-    use tokio::signal::unix::{signal, SignalKind};
+    use tokio::signal::unix::{SignalKind, signal};
     let mut sigterm = signal(SignalKind::terminate())
         .expect("Unable to register shutdown handler; are you running a Unix-based OS?");
     let mut sigint = signal(SignalKind::interrupt())

--- a/src/sockets.rs
+++ b/src/sockets.rs
@@ -13,7 +13,7 @@ use hyper::{
 };
 use hyper_util::rt::{TokioExecutor, TokioIo};
 use reqwest::Response;
-use tokio::{io::AsyncWriteExt, task::JoinHandle};
+use tokio::{io::AsyncWriteExt, net::TcpStream, task::JoinHandle};
 use tracing::{debug, error, info, warn};
 
 use crate::{config::Config, errors::BeamConnectError, structs::MyStatusCode};
@@ -153,6 +153,22 @@ async fn execute_http_task(
         warn!("App {app} not authorized to access url {uri}");
         return Err(StatusCode::UNAUTHORIZED);
     };
+    if req.method() == hyper::Method::CONNECT {
+        let dst = match TcpStream::connect((
+            target.replace.authority.host(),
+            target.replace.authority.port_u16().unwrap_or(443),
+        ))
+        .await
+        {
+            Ok(dst) => dst,
+            Err(e) => {
+                warn!("Failed to connect to target: {e}");
+                return Err(StatusCode::INTERNAL_SERVER_ERROR);
+            }
+        };
+        tokio::spawn(forward_req_via_socket(req, dst));
+        return Ok(crate::Response::new(BoxBody::default()));
+    }
     *req.uri_mut() = {
         let mut parts = uri.to_owned().into_parts();
         if target.force_https {
@@ -282,11 +298,13 @@ pub(crate) async fn handle_via_sockets(
             warn!("Error doing handshake with proxy: {e}");
             StatusCode::BAD_GATEWAY
         })?;
-    let req_upgrade = if req.headers().contains_key(header::UPGRADE) {
-        req.extensions_mut().remove::<OnUpgrade>()
-    } else {
-        None
-    };
+    // Upgrade on either http connection upgrades like websockets or CONNECT requests
+    let req_upgrade =
+        if req.headers().contains_key(header::UPGRADE) || req.method() == hyper::Method::CONNECT {
+            Some(hyper::upgrade::on(&mut req))
+        } else {
+            None
+        };
     let resp_future = sender.send_request(req);
     let resp = if let Some(upgrade) = req_upgrade {
         let (resp, proxy_connection) = tokio::join!(resp_future, proxy_conn.without_shutdown());
@@ -325,4 +343,17 @@ pub(crate) async fn handle_via_sockets(
         StatusCode::BAD_GATEWAY
     })?;
     Ok(resp.map(|b| BoxBody::new(b.map_err(Into::into))))
+}
+
+async fn forward_req_via_socket(req: Request<Incoming>, mut dst: TcpStream) {
+    let conn = match hyper::upgrade::on(req).await {
+        Ok(conn) => conn,
+        Err(e) => {
+            warn!("Failed to upgrade connection: {e}");
+            return;
+        }
+    };
+    if let Err(e) = tokio::io::copy_bidirectional(&mut TokioIo::new(conn), &mut dst).await {
+        warn!("Error relaying connection from client to proxy: {e}");
+    }
 }

--- a/src/sockets.rs
+++ b/src/sockets.rs
@@ -1,16 +1,22 @@
-use std::{time::Duration, collections::HashSet, convert::Infallible};
+use std::{collections::HashSet, convert::Infallible, time::Duration};
 
+use beam_lib::{AppId, AppOrProxyId, MsgId, SocketTask};
 use futures_util::TryStreamExt;
-use http_body_util::{combinators::BoxBody, BodyExt, BodyStream, StreamBody};
-use hyper::{body::Incoming, header, http::{uri::PathAndQuery, HeaderValue}, service::service_fn, upgrade::OnUpgrade, Request, StatusCode, Uri};
+use http_body_util::{BodyExt, BodyStream, StreamBody, combinators::BoxBody};
+use hyper::{
+    Request, StatusCode, Uri,
+    body::Incoming,
+    header,
+    http::{HeaderValue, uri::PathAndQuery},
+    service::service_fn,
+    upgrade::OnUpgrade,
+};
 use hyper_util::rt::{TokioExecutor, TokioIo};
-use tokio::{io::AsyncWriteExt, task::JoinHandle};
-use tracing::{error, warn, debug, info};
-use beam_lib::{SocketTask, MsgId, AppId, AppOrProxyId};
 use reqwest::Response;
+use tokio::{io::AsyncWriteExt, task::JoinHandle};
+use tracing::{debug, error, info, warn};
 
 use crate::{config::Config, errors::BeamConnectError, structs::MyStatusCode};
-
 
 pub(crate) fn spawn_socket_task_poller(config: &'static Config) -> JoinHandle<()> {
     tokio::spawn(async move {
@@ -24,7 +30,7 @@ pub(crate) fn spawn_socket_task_poller(config: &'static Config) -> JoinHandle<()
                     error!("{e}");
                     error!("This is most likely caused by wrong configuration");
                     break;
-                },
+                }
                 Err(ProxyTimeoutError) => continue,
                 Err(e) => {
                     warn!("Error during socket task polling: {e}");
@@ -46,7 +52,7 @@ pub(crate) fn spawn_socket_task_poller(config: &'static Config) -> JoinHandle<()
                         Ok(resp) => tunnel(resp, client, config).await,
                         Err(e) => {
                             warn!("{e}");
-                        },
+                        }
                     };
                 });
             }
@@ -55,7 +61,8 @@ pub(crate) fn spawn_socket_task_poller(config: &'static Config) -> JoinHandle<()
 }
 
 async fn poll_socket_task(config: &Config) -> Result<Vec<SocketTask>, BeamConnectError> {
-    let resp = config.client
+    let resp = config
+        .client
         .get(format!("{}v1/sockets", config.proxy_url))
         .header(header::AUTHORIZATION, config.proxy_auth.clone())
         .header(header::ACCEPT, "application/json")
@@ -63,15 +70,22 @@ async fn poll_socket_task(config: &Config) -> Result<Vec<SocketTask>, BeamConnec
         .await
         .map_err(BeamConnectError::ProxyReqwestError)?;
     match resp.status() {
-        StatusCode::OK => {},
+        StatusCode::OK => {}
         StatusCode::GATEWAY_TIMEOUT => return Err(BeamConnectError::ProxyTimeoutError),
-        e => return Err(BeamConnectError::ProxyOtherError(format!("Unexpected status code {e}")))
+        e => {
+            return Err(BeamConnectError::ProxyOtherError(format!(
+                "Unexpected status code {e}"
+            )));
+        }
     };
-    resp.json().await.map_err(BeamConnectError::ProxyReqwestError)
+    resp.json()
+        .await
+        .map_err(BeamConnectError::ProxyReqwestError)
 }
 
 async fn connect_proxy(task_id: &MsgId, config: &Config) -> Result<Response, BeamConnectError> {
-    let resp = config.client
+    let resp = config
+        .client
         .get(format!("{}v1/sockets/{task_id}", config.proxy_url))
         .header(header::AUTHORIZATION, config.proxy_auth.clone())
         .header(header::UPGRADE, "tcp")
@@ -80,13 +94,11 @@ async fn connect_proxy(task_id: &MsgId, config: &Config) -> Result<Response, Bea
         .map_err(BeamConnectError::ProxyReqwestError)?;
     let invalid_status_reason = match resp.status() {
         StatusCode::SWITCHING_PROTOCOLS => return Ok(resp),
-        StatusCode::NOT_FOUND | StatusCode::GONE => {
-            "Task already expired".to_string()
-        },
+        StatusCode::NOT_FOUND | StatusCode::GONE => "Task already expired".to_string(),
         StatusCode::UNAUTHORIZED => {
             "This socket is not for this authorized for this app".to_string()
         }
-        other => other.to_string()
+        other => other.to_string(),
     };
     Err(BeamConnectError::ProxyOtherError(invalid_status_reason))
 }
@@ -103,16 +115,23 @@ async fn tunnel(proxy: Response, client: AppId, config: &Config) {
         Err(e) => {
             warn!("Failed to upgrade connection to proxy: {e}");
             return;
-        },
+        }
     };
     let http_err = hyper_util::server::conn::auto::Builder::new(TokioExecutor::new())
-        .serve_connection_with_upgrades(TokioIo::new(proxy), service_fn(move |req| {
-            let client2 = client.clone();
-            let config2 = config.clone();
-            async move {
-                Ok::<_, Infallible>(execute_http_task(req, &client2, &config2).await.unwrap_or_else(status_to_response))
-            }
-        }))
+        .serve_connection_with_upgrades(
+            TokioIo::new(proxy),
+            service_fn(move |req| {
+                let client2 = client.clone();
+                let config2 = config.clone();
+                async move {
+                    Ok::<_, Infallible>(
+                        execute_http_task(req, &client2, &config2)
+                            .await
+                            .unwrap_or_else(status_to_response),
+                    )
+                }
+            }),
+        )
         .await;
 
     if let Err(e) = http_err {
@@ -120,7 +139,11 @@ async fn tunnel(proxy: Response, client: AppId, config: &Config) {
     }
 }
 
-async fn execute_http_task(mut req: Request<Incoming>, app: &AppId, config: &Config) -> Result<crate::Response, StatusCode> {
+async fn execute_http_task(
+    mut req: Request<Incoming>,
+    app: &AppId,
+    config: &Config,
+) -> Result<crate::Response, StatusCode> {
     let uri = req.uri();
     let Some(target) = config.targets_local.get(uri) else {
         warn!("Failed to lookup uri {uri}");
@@ -137,10 +160,20 @@ async fn execute_http_task(mut req: Request<Incoming>, app: &AppId, config: &Con
         }
         parts.authority = Some(target.replace.authority.clone());
         if let Some(path) = target.replace.path {
-            parts.path_and_query = Some(PathAndQuery::try_from(&format!("/{path}{}", parts.path_and_query.as_ref().map(PathAndQuery::as_str).unwrap_or(""))).map_err(|e| {
-                warn!("Failed to set redirect path: {e}");
-                StatusCode::INTERNAL_SERVER_ERROR
-            })?);
+            parts.path_and_query = Some(
+                PathAndQuery::try_from(&format!(
+                    "/{path}{}",
+                    parts
+                        .path_and_query
+                        .as_ref()
+                        .map(PathAndQuery::as_str)
+                        .unwrap_or("")
+                ))
+                .map_err(|e| {
+                    warn!("Failed to set redirect path: {e}");
+                    StatusCode::INTERNAL_SERVER_ERROR
+                })?,
+            );
         }
         Uri::from_parts(parts).map_err(|e| {
             warn!("Could not transform uri authority: {e}");
@@ -154,8 +187,18 @@ async fn execute_http_task(mut req: Request<Incoming>, app: &AppId, config: &Con
         None
     };
 
-    let mut resp = config.client
-        .execute(req.map(|b| reqwest::Body::wrap_stream(BodyStream::new(b).map_ok(|v| v.into_data().expect("TODO: How to handle trailers?")))).try_into().expect("This should always convert"))
+    let mut resp = config
+        .client
+        .execute(
+            req.map(|b| {
+                reqwest::Body::wrap_stream(
+                    BodyStream::new(b)
+                        .map_ok(|v| v.into_data().expect("TODO: How to handle trailers?")),
+                )
+            })
+            .try_into()
+            .expect("This should always convert"),
+        )
         .await
         .map_err(|e| {
             warn!("Error executuing http task. Failed handshake with server: {e}");
@@ -173,12 +216,16 @@ fn convert_to_hyper_response(resp: Response) -> crate::Response {
     let mut builder = hyper::http::response::Builder::new()
         .status(resp.status())
         .version(resp.version());
-    builder.headers_mut().map(|headers| *headers = resp.headers().clone());
+    builder
+        .headers_mut()
+        .map(|headers| *headers = resp.headers().clone());
     let stream = resp
         .bytes_stream()
         .map_ok(hyper::body::Frame::data)
         .map_err(Into::into);
-    builder.body(BoxBody::new(StreamBody::new(stream))).expect("This should always convert")
+    builder
+        .body(BoxBody::new(StreamBody::new(stream)))
+        .expect("This should always convert")
 }
 
 fn tunnel_upgrade(client: Option<OnUpgrade>, server: Option<OnUpgrade>) {
@@ -188,10 +235,12 @@ fn tunnel_upgrade(client: Option<OnUpgrade>, server: Option<OnUpgrade>) {
                 Err(e) => {
                     warn!("Upgrading connection between client and beam-connect failed: {e}");
                     return;
-                },
-                Ok(sockets) => sockets
+                }
+                Ok(sockets) => sockets,
             };
-            let result = tokio::io::copy_bidirectional(&mut TokioIo::new(client), &mut TokioIo::new(proxy)).await;
+            let result =
+                tokio::io::copy_bidirectional(&mut TokioIo::new(client), &mut TokioIo::new(proxy))
+                    .await;
             if let Err(e) = result {
                 debug!("Relaying socket connection ended: {e}");
             }
@@ -199,8 +248,14 @@ fn tunnel_upgrade(client: Option<OnUpgrade>, server: Option<OnUpgrade>) {
     }
 }
 
-pub(crate) async fn handle_via_sockets(mut req: Request<Incoming>, config: &Config, target: &AppId, auth: HeaderValue) -> Result<crate::Response, MyStatusCode> {
-    let resp = config.client
+pub(crate) async fn handle_via_sockets(
+    mut req: Request<Incoming>,
+    config: &Config,
+    target: &AppId,
+    auth: HeaderValue,
+) -> Result<crate::Response, MyStatusCode> {
+    let resp = config
+        .client
         .post(format!("{}v1/sockets/{target}", config.proxy_url))
         .header(header::AUTHORIZATION, auth)
         .header(header::UPGRADE, "tcp")
@@ -209,8 +264,7 @@ pub(crate) async fn handle_via_sockets(mut req: Request<Incoming>, config: &Conf
         .map_err(|e| {
             warn!("Failed to reach proxy: {e}");
             StatusCode::BAD_GATEWAY
-        }
-    )?;
+        })?;
     if resp.status() != StatusCode::SWITCHING_PROTOCOLS {
         return Err(resp.status().into());
     }
@@ -249,14 +303,17 @@ pub(crate) async fn handle_via_sockets(mut req: Request<Incoming>, config: &Conf
                             warn!("Failed to send initial bytes from remote to client: {e}");
                         }
                     }
-                    if let Err(e) = tokio::io::copy_bidirectional(&mut client, &mut TokioIo::new(proxy_io.io)).await {
+                    if let Err(e) =
+                        tokio::io::copy_bidirectional(&mut client, &mut TokioIo::new(proxy_io.io))
+                            .await
+                    {
                         debug!("Error relaying connection from client to proxy: {e}");
                     }
                 });
-            },
+            }
             Err(e) => {
                 warn!("Connection failed: {e}");
-            },
+            }
         };
         resp
     } else {

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -1,10 +1,10 @@
-use std::{string::FromUtf8Error, error::Error, fmt::Display};
+use std::{error::Error, fmt::Display, string::FromUtf8Error};
 
 use hyper::{StatusCode, header::ToStrError};
 
 #[derive(Debug)]
 pub(crate) struct MyStatusCode {
-    pub(crate) code: StatusCode
+    pub(crate) code: StatusCode,
 }
 
 impl From<StatusCode> for MyStatusCode {
@@ -15,7 +15,9 @@ impl From<StatusCode> for MyStatusCode {
 
 impl From<ToStrError> for MyStatusCode {
     fn from(_: ToStrError) -> Self {
-        Self { code: StatusCode::BAD_REQUEST }
+        Self {
+            code: StatusCode::BAD_REQUEST,
+        }
     }
 }
 
@@ -27,13 +29,17 @@ impl From<MyStatusCode> for StatusCode {
 
 impl From<FromUtf8Error> for MyStatusCode {
     fn from(_: FromUtf8Error) -> Self {
-        Self { code: StatusCode::UNPROCESSABLE_ENTITY }
+        Self {
+            code: StatusCode::UNPROCESSABLE_ENTITY,
+        }
     }
 }
 
 impl From<serde_json::Error> for MyStatusCode {
     fn from(_: serde_json::Error) -> Self {
-        Self { code: StatusCode::UNPROCESSABLE_ENTITY }
+        Self {
+            code: StatusCode::UNPROCESSABLE_ENTITY,
+        }
     }
 }
 

--- a/tests/base_tests.rs
+++ b/tests/base_tests.rs
@@ -147,7 +147,7 @@ mod socket_tests {
         tungstenite::{Message, protocol::Role},
     };
 
-    use crate::common::TEST_CLIENT;
+    use crate::common::{TEST_CLIENT, TEST_CLIENT_SOCKET_PROXY};
 
     #[tokio::test]
     pub async fn test_ws() {
@@ -171,5 +171,20 @@ mod socket_tests {
         let res = stream.next().await.unwrap().unwrap();
         assert_eq!(res, Message::Text("Hello World".to_string().into()));
         stream.close(None).await.unwrap();
+    }
+
+    #[tokio::test]
+    pub async fn test_connect() -> anyhow::Result<()> {
+        let resp = TEST_CLIENT_SOCKET_PROXY
+            .get(format!("https://echo-get/get"))
+            .body("test")
+            .send()
+            .await?
+            .json::<serde_json::Value>()
+            .await?;
+        assert_eq!(resp["body"].as_str(), Some("test"));
+        assert_eq!(resp["path"].as_str(), Some("/get"));
+        assert_eq!(resp["protocol"].as_str(), Some("https"));
+        Ok(())
     }
 }

--- a/tests/base_tests.rs
+++ b/tests/base_tests.rs
@@ -6,13 +6,25 @@ mod common;
 use common::TEST_CLIENT;
 
 pub async fn test_normal(scheme: &str) {
-    let res = TEST_CLIENT.get(format!("{scheme}://echo-get?foo1=bar1&foo2=bar2")).send().await.unwrap();
-    assert_eq!(res.status(), StatusCode::OK, "Could not make normal request via beam-connect");
+    let res = TEST_CLIENT
+        .get(format!("{scheme}://echo-get?foo1=bar1&foo2=bar2"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        res.status(),
+        StatusCode::OK,
+        "Could not make normal request via beam-connect"
+    );
     let received: Value = res.json().await.unwrap();
-    assert_eq!(received.get("query").unwrap(), &json!({
-        "foo1": "bar1",
-        "foo2": "bar2"
-    }), "Json did not match");
+    assert_eq!(
+        received.get("query").unwrap(),
+        &json!({
+            "foo1": "bar1",
+            "foo2": "bar2"
+        }),
+        "Json did not match"
+    );
     assert_eq!(received.get("path"), Some(&json!("/get/")))
 }
 
@@ -22,79 +34,140 @@ pub async fn test_json(scheme: &str) {
         "bar": "foo",
         "foobar": false,
     });
-    let res = TEST_CLIENT.post(format!("{scheme}://echo-post")).json(&json).send().await.unwrap();
-    assert_eq!(res.status(), StatusCode::OK, "Could not make json request via beam-connect");
+    let res = TEST_CLIENT
+        .post(format!("{scheme}://echo-post"))
+        .json(&json)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        res.status(),
+        StatusCode::OK,
+        "Could not make json request via beam-connect"
+    );
     let received: Value = res.json().await.unwrap();
-    assert_eq!(received.get("body").and_then(Value::as_str).and_then(|s| serde_json::from_str::<Value>(s).ok()).unwrap(), json, "Json did not match");
+    assert_eq!(
+        received
+            .get("body")
+            .and_then(Value::as_str)
+            .and_then(|s| serde_json::from_str::<Value>(s).ok())
+            .unwrap(),
+        json,
+        "Json did not match"
+    );
     assert_eq!(received.get("path"), Some(&json!("/post/")))
 }
 
 pub async fn test_path_match(scheme: &str) {
-    let res = TEST_CLIENT.get(format!("{scheme}://echo-allowed/foo/bar/allowed")).send().await.unwrap();
-    assert_eq!(res.status(), StatusCode::OK, "Could not make normal request via beam-connect");
+    let res = TEST_CLIENT
+        .get(format!("{scheme}://echo-allowed/foo/bar/allowed"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        res.status(),
+        StatusCode::OK,
+        "Could not make normal request via beam-connect"
+    );
     let received: Value = res.json().await.unwrap();
     assert_eq!(received.get("path"), Some(&json!("/get/foo/bar/allowed")))
 }
 
 pub async fn test_replace_header(scheme: &str) {
-    let res = TEST_CLIENT.get(format!("{scheme}://invalid-authority?foo1=bar1&foo2=bar2")).header("x-replace-host", "echo-get").send().await.unwrap();
-    assert_eq!(res.status(), StatusCode::OK, "Could not make normal request with header replacement via beam-connect");
+    let res = TEST_CLIENT
+        .get(format!("{scheme}://invalid-authority?foo1=bar1&foo2=bar2"))
+        .header("x-replace-host", "echo-get")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        res.status(),
+        StatusCode::OK,
+        "Could not make normal request with header replacement via beam-connect"
+    );
     let received: Value = res.json().await.unwrap();
-    assert_eq!(received.get("query").unwrap(), &json!({
-        "foo1": "bar1",
-        "foo2": "bar2"
-    }), "Json did not match");
+    assert_eq!(
+        received.get("query").unwrap(),
+        &json!({
+            "foo1": "bar1",
+            "foo2": "bar2"
+        }),
+        "Json did not match"
+    );
     assert_eq!(received.get("path"), Some(&json!("/get/")))
 }
 
-#[tokio::test] 
-pub async fn test_empty_authority() { // Test only works with http, so no macro usage
+#[tokio::test]
+pub async fn test_empty_authority() {
+    // Test only works with http, so no macro usage
     let client = Client::builder()
         .danger_accept_invalid_certs(true)
         .build()
         .unwrap();
-    let res = client.get("http://localhost:8062")
-        .query(&[("foo1","bar1"),("foo2","bar2")])
+    let res = client
+        .get("http://localhost:8062")
+        .query(&[("foo1", "bar1"), ("foo2", "bar2")])
         .header(header::HOST, "echo-get")
-        .header(header::PROXY_AUTHORIZATION, "ApiKey app1.proxy1.broker App1Secret")
-        .send().await
+        .header(
+            header::PROXY_AUTHORIZATION,
+            "ApiKey app1.proxy1.broker App1Secret",
+        )
+        .send()
+        .await
         .unwrap();
-    assert_eq!(res.status(), StatusCode::OK, "Could not make normal request via beam-connect");
+    assert_eq!(
+        res.status(),
+        StatusCode::OK,
+        "Could not make normal request via beam-connect"
+    );
     let received: Value = res.json().await.unwrap();
-    assert_eq!(received.get("query").unwrap(), &json!({
-        "foo1": "bar1",
-        "foo2": "bar2"
-    }), "Json did not match");
+    assert_eq!(
+        received.get("query").unwrap(),
+        &json!({
+            "foo1": "bar1",
+            "foo2": "bar2"
+        }),
+        "Json did not match"
+    );
     assert_eq!(received.get("path"), Some(&json!("/get/")))
 }
 
-test_http_and_https!{test_normal}
-test_http_and_https!{test_json}
-test_http_and_https!{test_replace_header}
-test_http_and_https!{test_path_match}
+test_http_and_https! {test_normal}
+test_http_and_https! {test_json}
+test_http_and_https! {test_replace_header}
+test_http_and_https! {test_path_match}
 
 #[cfg(feature = "sockets")]
 #[cfg(test)]
 mod socket_tests {
     use futures_util::{SinkExt, StreamExt};
-    use hyper::{header, StatusCode};
-    use tokio_tungstenite::{tungstenite::{protocol::Role, Message}, WebSocketStream};
+    use hyper::{StatusCode, header};
+    use tokio_tungstenite::{
+        WebSocketStream,
+        tungstenite::{Message, protocol::Role},
+    };
 
     use crate::common::TEST_CLIENT;
-    
+
     #[tokio::test]
     pub async fn test_ws() {
-        let resp = TEST_CLIENT.get(format!("http://ws-echo"))
+        let resp = TEST_CLIENT
+            .get(format!("http://ws-echo"))
             .header(header::UPGRADE, "websocket")
             .header(header::CONNECTION, "upgrade")
             .header(header::SEC_WEBSOCKET_VERSION, "13")
             .header(header::SEC_WEBSOCKET_KEY, "h/QU7Qscq6DfSTu9aP78HQ==")
-            .send().await.unwrap();
+            .send()
+            .await
+            .unwrap();
         assert_eq!(resp.status(), StatusCode::SWITCHING_PROTOCOLS);
         let socket = resp.upgrade().await.unwrap();
         let mut stream = WebSocketStream::from_raw_socket(socket, Role::Client, None).await;
         let _server_hello = stream.next().await.unwrap().unwrap();
-        stream.send(Message::Text("Hello World".to_string().into())).await.unwrap();
+        stream
+            .send(Message::Text("Hello World".to_string().into()))
+            .await
+            .unwrap();
         let res = stream.next().await.unwrap().unwrap();
         assert_eq!(res, Message::Text("Hello World".to_string().into()));
         stream.close(None).await.unwrap();

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,6 +1,5 @@
-
+use hyper::{HeaderMap, header, http::HeaderValue};
 use once_cell::sync::Lazy;
-use hyper::{header, http::HeaderValue, HeaderMap};
 use reqwest::{Client, Proxy};
 
 pub static TEST_CLIENT: Lazy<Client> = Lazy::new(|| {
@@ -9,7 +8,10 @@ pub static TEST_CLIENT: Lazy<Client> = Lazy::new(|| {
         .proxy(Proxy::all("http://localhost:8062").unwrap())
         .default_headers({
             let mut headers = HeaderMap::new();
-            headers.append(header::PROXY_AUTHORIZATION, HeaderValue::from_static("ApiKey app1.proxy1.broker App1Secret"));
+            headers.append(
+                header::PROXY_AUTHORIZATION,
+                HeaderValue::from_static("ApiKey app1.proxy1.broker App1Secret"),
+            );
             headers
         })
         .build()

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -18,6 +18,21 @@ pub static TEST_CLIENT: Lazy<Client> = Lazy::new(|| {
         .unwrap()
 });
 
+#[cfg(feature = "sockets")]
+pub static TEST_CLIENT_SOCKET_PROXY: Lazy<Client> = Lazy::new(|| {
+    Client::builder()
+        .danger_accept_invalid_certs(true)
+        .proxy(
+            Proxy::all("http://localhost:8063")
+                .unwrap()
+                .custom_http_auth(HeaderValue::from_static(
+                    "ApiKey app2.proxy2.broker App1Secret"
+                )),
+        )
+        .build()
+        .unwrap()
+});
+
 #[macro_export]
 macro_rules! test_http_and_https {
     ($name:ident) => {


### PR DESCRIPTION
First commit can be ignored.

This makes the tls termination feature optional and keeps the docker image compatible by defaulting the env vars to what the cli defaults where before.

Regarding the tunneling very little logic needed to be adjusted.
On the client side we just need to tell hyper to upgrade (i.e. not shutdown the request after the response) the request and can fully reuse the logic for regular http upgrades as used by WS etc.
On the upstream we just add a special path for CONNECT where all we do is a tcp connect to the local targets host. After which we reply with the 200 Connection established and tunnel the traffic.