### PR TITLE
don't spawn socket task poller when we don't have local targets

### DIFF
--- a/src/logic_reply.rs
+++ b/src/logic_reply.rs
@@ -5,13 +5,45 @@ use futures_util::future::TryJoinAll;
 use hyper::{Method, StatusCode, Uri, header, http::uri::PathAndQuery};
 use reqwest::Response;
 use serde_json::Value;
-use tracing::{Instrument, Span, debug, field, info, trace, warn};
+use tokio::time::Instant;
+use tracing::{Instrument, Span, debug, error, field, info, trace, warn};
 
 use crate::{
     config::Config,
     errors::BeamConnectError,
     msg::{HttpRequest, HttpResponse},
 };
+
+pub async fn http_beam_task_executor(config: &'static Config) {
+    let mut tries = 0_u32;
+    let mut timer = std::pin::pin!(tokio::time::sleep(Duration::from_secs(60)));
+    loop {
+        debug!("Waiting for next request ...");
+        if let Err(e) = process_requests(config).await {
+            match e {
+                BeamConnectError::ProxyTimeoutError => (),
+                BeamConnectError::ProxyRejectedAuthorization => {
+                    error!("Stopping task polling: {e}");
+                    break;
+                }
+                _ if tries < 10 => {
+                    tries += 1;
+                    warn!("Error in processing request: {e}. Will continue with the next one.");
+                }
+                _ => {
+                    warn!("Failed to process requests: {e}. Retrying in 30s.");
+                    tokio::time::sleep(Duration::from_secs(30)).await;
+                }
+            }
+        }
+        if timer.is_elapsed() {
+            tries = tries.saturating_sub(2);
+            timer
+                .as_mut()
+                .reset(Instant::now() + Duration::from_secs(60));
+        }
+    }
+}
 
 pub(crate) async fn process_requests(config: &'static Config) -> Result<(), BeamConnectError> {
     // Fetch a batch of tasks and executed them in parallel

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,11 +12,9 @@ use hyper_util::{
     server,
 };
 use logic_ask::handler_http;
-use tokio::{net::TcpListener, task::JoinHandle, time::Instant};
+use tokio::{net::TcpListener, task::JoinHandle};
 use tracing::{debug, error, info, warn};
 use tracing_subscriber::{EnvFilter, filter::LevelFilter};
-
-use crate::errors::BeamConnectError;
 
 mod banner;
 mod config;
@@ -49,44 +47,14 @@ async fn main() -> anyhow::Result<()> {
     info!("Global site discovery: {:?}", config.targets_public);
     info!("Local site Access: {:?}", config.targets_local);
 
-    let http_executor = tokio::task::spawn(async move {
-        if config.targets_local.entries.is_empty() {
-            info!("No local targets configured, will not poll for tasks.");
-            return;
-        };
-        let mut tries = 0_u32;
-        let mut timer = std::pin::pin!(tokio::time::sleep(Duration::from_secs(60)));
-        loop {
-            debug!("Waiting for next request ...");
-            if let Err(e) = logic_reply::process_requests(config).await {
-                match e {
-                    BeamConnectError::ProxyTimeoutError => (),
-                    BeamConnectError::ProxyRejectedAuthorization => {
-                        error!("Stopping task polling: {e}");
-                        break;
-                    }
-                    _ if tries < 10 => {
-                        tries += 1;
-                        warn!("Error in processing request: {e}. Will continue with the next one.");
-                    }
-                    _ => {
-                        warn!("Failed to process requests: {e}. Retrying in 30s.");
-                        tokio::time::sleep(Duration::from_secs(30)).await;
-                    }
-                }
-            }
-            if timer.is_elapsed() {
-                tries = tries.saturating_sub(2);
-                timer
-                    .as_mut()
-                    .reset(Instant::now() + Duration::from_secs(60));
-            }
-        }
-    });
-    #[allow(unused_mut)]
-    let mut executers = vec![http_executor];
-    #[cfg(feature = "sockets")]
-    executers.push(sockets::spawn_socket_task_poller(config));
+    let mut executers = vec![];
+    if !config.targets_local.entries.is_empty() {
+        executers.push(tokio::spawn(logic_reply::http_beam_task_executor(config)));
+        #[cfg(feature = "sockets")]
+        executers.push(tokio::spawn(sockets::socket_task_poller(config)));
+    } else {
+        info!("No local targets configured, will not poll for tasks.");
+    };
 
     if let Err(e) = server(config).await {
         error!("Server error: {}", e);

--- a/src/sockets.rs
+++ b/src/sockets.rs
@@ -13,51 +13,49 @@ use hyper::{
 };
 use hyper_util::rt::{TokioExecutor, TokioIo};
 use reqwest::Response;
-use tokio::{io::AsyncWriteExt, net::TcpStream, task::JoinHandle};
+use tokio::{io::AsyncWriteExt, net::TcpStream};
 use tracing::{debug, error, info, warn};
 
 use crate::{config::Config, errors::BeamConnectError, structs::MyStatusCode};
 
-pub(crate) fn spawn_socket_task_poller(config: &'static Config) -> JoinHandle<()> {
-    tokio::spawn(async move {
-        use BeamConnectError::*;
-        let mut seen: HashSet<MsgId> = HashSet::new();
+pub(crate) async fn socket_task_poller(config: &'static Config) {
+    use BeamConnectError::*;
+    let mut seen: HashSet<MsgId> = HashSet::new();
 
-        loop {
-            let tasks = match poll_socket_task(&config).await {
-                Ok(tasks) => tasks,
-                Err(HyperBuildError(e)) => {
-                    error!("{e}");
-                    error!("This is most likely caused by wrong configuration");
-                    break;
-                }
-                Err(ProxyTimeoutError) => continue,
-                Err(e) => {
-                    warn!("Error during socket task polling: {e}");
-                    tokio::time::sleep(Duration::from_secs(10)).await;
-                    continue;
-                }
-            };
-            for task in tasks {
-                if seen.contains(&task.id) {
-                    continue;
-                }
-                seen.insert(task.id.clone());
-                let AppOrProxyId::App(client) = task.from else {
-                    warn!("Invalid app id skipping");
-                    continue;
-                };
-                tokio::spawn(async move {
-                    match connect_proxy(&task.id, config).await {
-                        Ok(resp) => tunnel(resp, client, config).await,
-                        Err(e) => {
-                            warn!("{e}");
-                        }
-                    };
-                });
+    loop {
+        let tasks = match poll_socket_task(&config).await {
+            Ok(tasks) => tasks,
+            Err(HyperBuildError(e)) => {
+                error!("{e}");
+                error!("This is most likely caused by wrong configuration");
+                break;
             }
+            Err(ProxyTimeoutError) => continue,
+            Err(e) => {
+                warn!("Error during socket task polling: {e}");
+                tokio::time::sleep(Duration::from_secs(10)).await;
+                continue;
+            }
+        };
+        for task in tasks {
+            if seen.contains(&task.id) {
+                continue;
+            }
+            seen.insert(task.id.clone());
+            let AppOrProxyId::App(client) = task.from else {
+                warn!("Invalid app id skipping");
+                continue;
+            };
+            tokio::spawn(async move {
+                match connect_proxy(&task.id, config).await {
+                    Ok(resp) => tunnel(resp, client, config).await,
+                    Err(e) => {
+                        warn!("{e}");
+                    }
+                };
+            });
         }
-    })
+    }
 }
 
 async fn poll_socket_task(config: &Config) -> Result<Vec<SocketTask>, BeamConnectError> {


### PR DESCRIPTION
This optimization was already done for the regular task poller. This just refactors the check to apply to both