### PR TITLE
refactor polling

### DIFF
--- a/src/logic_reply.rs
+++ b/src/logic_reply.rs
@@ -14,38 +14,43 @@ use crate::{
     msg::{HttpRequest, HttpResponse},
 };
 
-pub async fn http_beam_task_executor(config: &'static Config) {
+pub async fn poller<F, Fut>(f: F)
+where
+    F: Fn() -> Fut,
+    Fut: Future<Output = Result<(), BeamConnectError>>,
+{
     let mut tries = 0_u32;
-    let mut timer = std::pin::pin!(tokio::time::sleep(Duration::from_secs(60)));
+    let mut timer = Instant::now();
     loop {
         debug!("Waiting for next request ...");
-        if let Err(e) = process_requests(config).await {
-            match e {
-                BeamConnectError::ProxyTimeoutError => (),
-                BeamConnectError::ProxyRejectedAuthorization => {
-                    error!("Stopping task polling: {e}");
-                    break;
-                }
-                _ if tries < 10 => {
-                    tries += 1;
-                    warn!("Error in processing request: {e}. Will continue with the next one.");
-                }
-                _ => {
-                    warn!("Failed to process requests: {e}. Retrying in 30s.");
-                    tokio::time::sleep(Duration::from_secs(30)).await;
-                }
+        match f().await {
+            Ok(()) => (),
+            Err(BeamConnectError::ProxyReqwestError(e)) if e.is_connect() => {
+                info!("Trying to connect to beam-proxy. Retrying in 1s.");
+                tokio::time::sleep(Duration::from_secs(1)).await;
+            }
+            Err(BeamConnectError::ProxyTimeoutError) => tries += 1,
+            Err(e @ BeamConnectError::ProxyRejectedAuthorization) => {
+                error!("Stopping polling: {e}");
+                break;
+            }
+            Err(e) if tries < 10 => {
+                tries += 1;
+                warn!("Error while polling: {e}. Will continue with the next one.");
+            }
+            Err(e) => {
+                warn!("Error while polling: {e}. Retrying in 10s.");
+                tokio::time::sleep(Duration::from_secs(10)).await;
             }
         }
-        if timer.is_elapsed() {
+        if timer + Duration::from_secs(60) < Instant::now() {
             tries = tries.saturating_sub(2);
-            timer
-                .as_mut()
-                .reset(Instant::now() + Duration::from_secs(60));
+            timer = Instant::now();
         }
     }
 }
 
-pub(crate) async fn process_requests(config: &'static Config) -> Result<(), BeamConnectError> {
+pub(crate) async fn poll_and_execute_task(config: &'static Config) -> Result<(), BeamConnectError> {
     // Fetch a batch of tasks and executed them in parallel
     fetch_task(&config)
         .await?
@@ -263,7 +268,6 @@ async fn execute_http_task(
 
 async fn fetch_task(config: &Config) -> Result<Vec<TaskRequest<HttpRequest>>, BeamConnectError> {
     debug!("fetching requests from proxy");
-    let probably_timeout = tokio::time::sleep(Duration::from_secs(20));
     let resp = config
         .client
         .get(format!(
@@ -279,12 +283,10 @@ async fn fetch_task(config: &Config) -> Result<Vec<TaskRequest<HttpRequest>>, Be
         StatusCode::OK | StatusCode::PARTIAL_CONTENT => {
             trace!("Got tasks from beam: {resp:#?}");
         }
-        StatusCode::GATEWAY_TIMEOUT => return Err(BeamConnectError::ProxyTimeoutError),
-        StatusCode::UNAUTHORIZED => return Err(BeamConnectError::ProxyRejectedAuthorization),
-        s if probably_timeout.is_elapsed() => {
-            debug!("Request to proxy timed out with StatusCode {s}");
+        StatusCode::GATEWAY_TIMEOUT | StatusCode::BAD_GATEWAY => {
             return Err(BeamConnectError::ProxyTimeoutError);
         }
+        StatusCode::UNAUTHORIZED => return Err(BeamConnectError::ProxyRejectedAuthorization),
         _ => {
             return Err(BeamConnectError::ProxyOtherError(format!(
                 "Got response code {}",

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ use hyper_util::{
     server,
 };
 use logic_ask::handler_http;
+use logic_reply::poller;
 use tokio::{net::TcpListener, task::JoinHandle};
 use tracing::{debug, error, info, warn};
 use tracing_subscriber::{EnvFilter, filter::LevelFilter};
@@ -49,9 +50,13 @@ async fn main() -> anyhow::Result<()> {
 
     let mut executers = vec![];
     if !config.targets_local.entries.is_empty() {
-        executers.push(tokio::spawn(logic_reply::http_beam_task_executor(config)));
+        executers.push(tokio::spawn(poller(move || {
+            logic_reply::poll_and_execute_task(config)
+        })));
         #[cfg(feature = "sockets")]
-        executers.push(tokio::spawn(sockets::socket_task_poller(config)));
+        executers.push(tokio::spawn(poller(move || {
+            sockets::poll_and_execute_socket_task(config)
+        })));
     } else {
         info!("No local targets configured, will not poll for tasks.");
     };

--- a/src/sockets.rs
+++ b/src/sockets.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashSet, convert::Infallible, time::Duration};
+use std::{convert::Infallible, time::Duration};
 
 use beam_lib::{AppId, AppOrProxyId, MsgId, SocketTask};
 use futures_util::TryStreamExt;
@@ -18,44 +18,23 @@ use tracing::{debug, error, info, warn};
 
 use crate::{config::Config, errors::BeamConnectError, structs::MyStatusCode};
 
-pub(crate) async fn socket_task_poller(config: &'static Config) {
-    use BeamConnectError::*;
-    let mut seen: HashSet<MsgId> = HashSet::new();
-
-    loop {
-        let tasks = match poll_socket_task(&config).await {
-            Ok(tasks) => tasks,
-            Err(HyperBuildError(e)) => {
-                error!("{e}");
-                error!("This is most likely caused by wrong configuration");
-                break;
-            }
-            Err(ProxyTimeoutError) => continue,
-            Err(e) => {
-                warn!("Error during socket task polling: {e}");
-                tokio::time::sleep(Duration::from_secs(10)).await;
-                continue;
-            }
+pub(crate) async fn poll_and_execute_socket_task(
+    config: &'static Config,
+) -> Result<(), BeamConnectError> {
+    let tasks = poll_socket_task(config).await?;
+    for task in tasks {
+        let AppOrProxyId::App(client) = task.from else {
+            warn!("Invalid app id skipping");
+            return Err(BeamConnectError::ReplyInvalid(format!(
+                "Invalid app id: {:?}",
+                task.from
+            )));
         };
-        for task in tasks {
-            if seen.contains(&task.id) {
-                continue;
-            }
-            seen.insert(task.id.clone());
-            let AppOrProxyId::App(client) = task.from else {
-                warn!("Invalid app id skipping");
-                continue;
-            };
-            tokio::spawn(async move {
-                match connect_proxy(&task.id, config).await {
-                    Ok(resp) => tunnel(resp, client, config).await,
-                    Err(e) => {
-                        warn!("{e}");
-                    }
-                };
-            });
-        }
+        let resp = connect_proxy(&task.id, config).await?;
+        // After the connection is established we can polling again for new socket tasks.
+        tokio::spawn(tunnel(resp, client, config));
     }
+    Ok(())
 }
 
 async fn poll_socket_task(config: &Config) -> Result<Vec<SocketTask>, BeamConnectError> {
@@ -69,7 +48,12 @@ async fn poll_socket_task(config: &Config) -> Result<Vec<SocketTask>, BeamConnec
         .map_err(BeamConnectError::ProxyReqwestError)?;
     match resp.status() {
         StatusCode::OK => {}
-        StatusCode::GATEWAY_TIMEOUT => return Err(BeamConnectError::ProxyTimeoutError),
+        StatusCode::UNAUTHORIZED => {
+            return Err(BeamConnectError::ProxyRejectedAuthorization);
+        }
+        StatusCode::GATEWAY_TIMEOUT | StatusCode::BAD_GATEWAY => {
+            return Err(BeamConnectError::ProxyTimeoutError);
+        }
         e => {
             return Err(BeamConnectError::ProxyOtherError(format!(
                 "Unexpected status code {e}"
@@ -93,9 +77,7 @@ async fn connect_proxy(task_id: &MsgId, config: &Config) -> Result<Response, Bea
     let invalid_status_reason = match resp.status() {
         StatusCode::SWITCHING_PROTOCOLS => return Ok(resp),
         StatusCode::NOT_FOUND | StatusCode::GONE => "Task already expired".to_string(),
-        StatusCode::UNAUTHORIZED => {
-            "This socket is not for this authorized for this app".to_string()
-        }
+        StatusCode::UNAUTHORIZED => "This socket task is not authorized for this app".to_string(),
         other => other.to_string(),
     };
     Err(BeamConnectError::ProxyOtherError(invalid_status_reason))
@@ -107,7 +89,7 @@ fn status_to_response(status: StatusCode) -> crate::Response {
     res
 }
 
-async fn tunnel(proxy: Response, client: AppId, config: &Config) {
+async fn tunnel(proxy: Response, client: AppId, config: &'static Config) {
     let proxy = match proxy.upgrade().await {
         Ok(socket) => socket,
         Err(e) => {
@@ -119,11 +101,10 @@ async fn tunnel(proxy: Response, client: AppId, config: &Config) {
         .serve_connection_with_upgrades(
             TokioIo::new(proxy),
             service_fn(move |req| {
-                let client2 = client.clone();
-                let config2 = config.clone();
+                let client = client.clone();
                 async move {
                     Ok::<_, Infallible>(
-                        execute_http_task(req, &client2, &config2)
+                        execute_http_task(req, &client, config)
                             .await
                             .unwrap_or_else(status_to_response),
                     )

--- a/src/sockets.rs
+++ b/src/sockets.rs
@@ -1,4 +1,4 @@
-use std::{convert::Infallible, time::Duration};
+use std::convert::Infallible;
 
 use beam_lib::{AppId, AppOrProxyId, MsgId, SocketTask};
 use futures_util::TryStreamExt;
@@ -14,7 +14,7 @@ use hyper::{
 use hyper_util::rt::{TokioExecutor, TokioIo};
 use reqwest::Response;
 use tokio::{io::AsyncWriteExt, net::TcpStream};
-use tracing::{debug, error, info, warn};
+use tracing::{Instrument, Span, debug, info, warn};
 
 use crate::{config::Config, errors::BeamConnectError, structs::MyStatusCode};
 
@@ -23,6 +23,8 @@ pub(crate) async fn poll_and_execute_socket_task(
 ) -> Result<(), BeamConnectError> {
     let tasks = poll_socket_task(config).await?;
     for task in tasks {
+        let span =
+            tracing::info_span!("socket task", from = %task.from.hide_broker(), id = %task.id);
         let AppOrProxyId::App(client) = task.from else {
             warn!("Invalid app id skipping");
             return Err(BeamConnectError::ReplyInvalid(format!(
@@ -30,9 +32,11 @@ pub(crate) async fn poll_and_execute_socket_task(
                 task.from
             )));
         };
-        let resp = connect_proxy(&task.id, config).await?;
+        let resp = connect_proxy(&task.id, config)
+            .instrument(span.clone())
+            .await?;
         // After the connection is established we can polling again for new socket tasks.
-        tokio::spawn(tunnel(resp, client, config));
+        tokio::spawn(tunnel(resp, client, config).instrument(span));
     }
     Ok(())
 }
@@ -47,7 +51,7 @@ async fn poll_socket_task(config: &Config) -> Result<Vec<SocketTask>, BeamConnec
         .await
         .map_err(BeamConnectError::ProxyReqwestError)?;
     match resp.status() {
-        StatusCode::OK => {}
+        StatusCode::OK | StatusCode::PARTIAL_CONTENT => {}
         StatusCode::UNAUTHORIZED => {
             return Err(BeamConnectError::ProxyRejectedAuthorization);
         }
@@ -118,6 +122,7 @@ async fn tunnel(proxy: Response, client: AppId, config: &'static Config) {
     }
 }
 
+#[tracing::instrument(skip_all, fields(method = %req.method(), orig_url = %req.uri(), destination))]
 async fn execute_http_task(
     mut req: Request<Incoming>,
     app: &AppId,
@@ -133,6 +138,10 @@ async fn execute_http_task(
         return Err(StatusCode::UNAUTHORIZED);
     };
     if req.method() == hyper::Method::CONNECT {
+        Span::current().record(
+            "destination",
+            tracing::field::display(&target.replace.authority),
+        );
         let dst = match TcpStream::connect((
             target.replace.authority.host(),
             target.replace.authority.port_u16().unwrap_or(443),
@@ -145,7 +154,7 @@ async fn execute_http_task(
                 return Err(StatusCode::INTERNAL_SERVER_ERROR);
             }
         };
-        tokio::spawn(forward_req_via_socket(req, dst));
+        tokio::spawn(forward_req_via_socket(req, dst).instrument(Span::current()));
         return Ok(crate::Response::new(BoxBody::default()));
     }
     *req.uri_mut() = {
@@ -175,7 +184,8 @@ async fn execute_http_task(
             StatusCode::INTERNAL_SERVER_ERROR
         })?
     };
-    info!("Requesting {} {}", req.method(), req.uri());
+    Span::current().record("destination", tracing::field::display(req.uri()));
+    info!("Executing socket request");
     let req_upgrade = if req.headers().contains_key(header::UPGRADE) {
         req.extensions_mut().remove::<OnUpgrade>()
     } else {
@@ -225,21 +235,26 @@ fn convert_to_hyper_response(resp: Response) -> crate::Response {
 
 fn tunnel_upgrade(client: Option<OnUpgrade>, server: Option<OnUpgrade>) {
     if let (Some(client), Some(proxy)) = (client, server) {
-        tokio::spawn(async move {
-            let (client, proxy) = match tokio::try_join!(client, proxy) {
-                Err(e) => {
-                    warn!("Upgrading connection between client and beam-connect failed: {e}");
-                    return;
+        tokio::spawn(
+            async move {
+                let (client, proxy) = match tokio::try_join!(client, proxy) {
+                    Err(e) => {
+                        warn!("Upgrading connection between client and beam-connect failed: {e}");
+                        return;
+                    }
+                    Ok(sockets) => sockets,
+                };
+                let result = tokio::io::copy_bidirectional(
+                    &mut TokioIo::new(client),
+                    &mut TokioIo::new(proxy),
+                )
+                .await;
+                if let Err(e) = result {
+                    debug!("Relaying socket connection ended: {e}");
                 }
-                Ok(sockets) => sockets,
-            };
-            let result =
-                tokio::io::copy_bidirectional(&mut TokioIo::new(client), &mut TokioIo::new(proxy))
-                    .await;
-            if let Err(e) = result {
-                debug!("Relaying socket connection ended: {e}");
             }
-        });
+            .instrument(Span::current()),
+        );
     }
 }
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -26,7 +26,7 @@ pub static TEST_CLIENT_SOCKET_PROXY: Lazy<Client> = Lazy::new(|| {
             Proxy::all("http://localhost:8063")
                 .unwrap()
                 .custom_http_auth(HeaderValue::from_static(
-                    "ApiKey app2.proxy2.broker App1Secret"
+                    "ApiKey app2.proxy2.broker App1Secret",
                 )),
         )
         .build()


### PR DESCRIPTION
Previously this actually did not work as intended at all.
It turns out that a `tokio::time::Sleep` will only ever be elapsed if its polled at least once.
This now also unifies the polling code so sockets should benefit from the error handeling as well.