### PR TITLE
improve retry logic when interacting with beam

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -90,6 +90,12 @@ struct CliArgs {
     #[clap(long, env, value_parser, default_value = "3600")]
     expire: u64,
 
+    /// Number of retries for fetching a reply from beam for an outgoing request.
+    /// AND
+    /// Number of retries for submitting a reply to beam for an incoming request.
+    #[clap(long, env, value_parser, default_value_t = 3)]
+    per_request_beam_retries: usize,
+
     /// If set will enable any local apps to authenticate without the `Proxy-Authorization` header.
     /// Security note: This allows any app with network access to beam-connect to send requests to any other beam-connect service in the beam network.
     #[clap(long, env, action)]
@@ -249,6 +255,7 @@ pub(crate) struct Config {
     pub(crate) client: Client,
     pub(crate) tls_acceptor: Option<Arc<TlsAcceptor>>,
     pub(crate) no_auth: bool,
+    pub(crate) per_request_beam_retries: usize,
 }
 
 fn load_local_targets(
@@ -430,6 +437,7 @@ impl Config {
             expire,
             client,
             tls_acceptor,
+            per_request_beam_retries: args.per_request_beam_retries,
         })
     }
 }

--- a/src/logic_ask.rs
+++ b/src/logic_ask.rs
@@ -7,6 +7,7 @@ use hyper::http::uri::{Authority, Scheme};
 use hyper::{Request, StatusCode, Uri, header};
 use serde_json::Value;
 use std::str::FromStr;
+use std::time::Duration;
 use tracing::{Instrument, debug, error, info, info_span, trace, warn};
 
 use crate::Response;
@@ -147,8 +148,7 @@ async fn handle_via_tasks(
         return Err(StatusCode::BAD_GATEWAY.into());
     }
 
-    let mut tries = 0_u8;
-    const MAX_RETRIES: u8 = 3;
+    let mut tries = 0;
     let resp = loop {
         let resp = config
             .client
@@ -168,16 +168,16 @@ async fn handle_via_tasks(
 
         match resp.status() {
             StatusCode::OK => break resp,
-            s if tries > MAX_RETRIES => {
+            s if tries > config.per_request_beam_retries => {
                 warn!("Error fetching reply, got code: {s}. Giving up");
                 return Err(StatusCode::BAD_GATEWAY)?;
             }
             s => {
                 warn!("Failed to fetch reply, status: {s}. Retrying");
+                tokio::time::sleep(Duration::from_secs(1)).await;
                 tries += 1;
             }
         };
-        tries += 1;
     };
 
     let mut task_results = resp

--- a/src/logic_reply.rs
+++ b/src/logic_reply.rs
@@ -171,27 +171,38 @@ async fn send_reply(
         body: reply_body,
     };
     debug!("Delivering response to Proxy: {msg:?}");
-    let resp = config
-        .client
-        .put(format!(
-            "{}v1/tasks/{}/results/{}",
-            config.proxy_url,
-            task.id,
-            config.my_app_id.clone()
-        ))
-        .header(header::AUTHORIZATION, config.proxy_auth.clone())
-        .json(&msg)
-        .send()
-        .await
-        .map_err(BeamConnectError::ProxyReqwestError)?;
+    let mut tries = 0;
+    loop {
+        let resp = config
+            .client
+            .put(format!(
+                "{}v1/tasks/{}/results/{}",
+                config.proxy_url,
+                task.id,
+                config.my_app_id.clone()
+            ))
+            .header(header::AUTHORIZATION, config.proxy_auth.clone())
+            .json(&msg)
+            .send()
+            .await
+            .map_err(BeamConnectError::ProxyReqwestError)?;
+        trace!("Put result beam reply: {resp:#?}");
 
-    if let StatusCode::CREATED | StatusCode::NO_CONTENT = resp.status() {
-        Ok(())
-    } else {
-        Err(BeamConnectError::ProxyOtherError(format!(
-            "Got error code {} trying to submit our result.",
-            resp.status()
-        )))
+        match resp.status() {
+            StatusCode::CREATED | StatusCode::NO_CONTENT => break Ok(()),
+            s if tries > config.per_request_beam_retries => {
+                warn!("Error fetching reply, got code: {s}. Giving up");
+                break Err(BeamConnectError::ProxyOtherError(format!(
+                    "Got error code {} trying to submit our result.",
+                    resp.status()
+                )));
+            }
+            s => {
+                warn!("Failed to submit reply, status: {s}. Retrying");
+                tokio::time::sleep(Duration::from_secs(1)).await;
+                tries += 1;
+            }
+        };
     }
 }
 


### PR DESCRIPTION
In the r federation they still sometimes get 502 errors and hangs but I feel like they are pretty rare on the client site (r) but are more common on the server site leading to the clients endlessly waiting for a result hence I think its a good idea to retry submission as well.
The itcf reverse proxy in front of our broker just seems awful and will 502 every 100th request or so. Hopefully this will improve the stability.